### PR TITLE
[Ship] Template — Agent RH recrutement v1

### DIFF
--- a/templates/agent-rh-recrutement/README.md
+++ b/templates/agent-rh-recrutement/README.md
@@ -1,0 +1,58 @@
+# Template AMR — Agent RH Recrutement
+
+Template de mandat prêt à l'emploi pour encadrer un agent IA déployé en assistance au recrutement (tri de CV, pré-qualification, prise de rendez-vous, rédaction d'offres, réponses candidats).
+
+## Pour qui
+
+- DRH et responsables recrutement d'ETI et grands comptes qui testent un agent IA interne ou tiers.
+- DPO et compliance officers qui doivent cadrer un déploiement déjà en cours.
+- Intégrateurs et cabinets de recrutement qui proposent des agents à leurs clients et doivent livrer une gouvernance traçable.
+
+## Contexte
+
+Depuis 2024, les outils de tri automatique de candidatures et d'entretien assisté par IA se multiplient. Le règlement européen sur l'intelligence artificielle (Règlement UE 2024/1689, dit « AI Act ») classe explicitement les systèmes d'IA utilisés pour le recrutement, la sélection et l'évaluation des candidats comme **à haut risque** (Annexe III, point 4). Cela déclenche des obligations lourdes : supervision humaine effective, tenue de registres, transparence vis-à-vis des personnes concernées, gestion documentée du risque.
+
+En parallèle, le RGPD encadre la décision automatisée (article 22) et le Code du travail français impose la pertinence et la transparence des méthodes d'évaluation (articles L.1221-6 à L.1221-9).
+
+Déployer un agent de recrutement sans mandat explicite et vérifiable, c'est laisser à la machine le soin de décider qui passe le premier filtre — sans piste d'audit opposable, sans borne juridique claire, sans point d'arrêt.
+
+## Trois exemples de déploiement concret
+
+1. **Tri de candidatures entrantes** : un agent lit les CV déposés sur un ATS, extrait compétences et expérience, propose un score de correspondance avec la fiche de poste. Aucune décision d'élimination n'est prise par l'agent seul ; le recruteur humain valide chaque rejet.
+2. **Pré-qualification par échange écrit** : l'agent dialogue avec le candidat pour compléter le CV (disponibilité, prétentions, mobilité), consigne les réponses, et remonte un dossier structuré au recruteur.
+3. **Rédaction et diffusion d'offres** : l'agent produit une offre à partir d'une fiche de poste interne, vérifie le respect des mentions légales obligatoires, publie sur les canaux autorisés. Aucune modification des critères de poste sans validation humaine.
+
+## Ce que ce template fournit
+
+- `mandate.yaml` : le mandat structuré prêt à charger dans un registre AMR, avec périmètre d'action, volumes maximum, restrictions explicites, seuils de supervision humaine, durée de validité, cartographie RGPD et AI Act.
+- `examples/` : trois variantes (permissive, restrictive, équilibrée) commentées, pour s'adapter au niveau de maturité de l'organisation.
+- `compliance/` : trois fiches courtes qui cartographient le mandat avec l'AI Act, le RGPD et les règles sectorielles RH françaises.
+- `deploy_guide.md` : checklist de mise en production et points d'attention.
+
+## Pourquoi c'est risqué sans mandat
+
+Un agent de recrutement sans mandat documenté expose l'organisation à plusieurs risques concrets :
+
+- **Sanctions AI Act** : jusqu'à 35 M€ ou 7 % du chiffre d'affaires mondial pour les manquements aux obligations sur systèmes à haut risque (AI Act, article 99).
+- **Sanctions RGPD** : jusqu'à 20 M€ ou 4 % du chiffre d'affaires en cas de décision automatisée non encadrée (article 22) ou d'absence d'analyse d'impact (article 35).
+- **Contentieux prud'homal** : un candidat écarté peut demander la communication des méthodes d'évaluation (Code du travail, article L.1221-9). Sans piste d'audit, la défense est fragilisée.
+- **Atteinte réputationnelle** : un biais de tri révélé publiquement, sans gouvernance à exhiber, coûte plus cher qu'une amende.
+
+Le mandat AMR ne supprime pas ces risques — il les **encadre** et les **documente** de manière opposable.
+
+## Positionnement tarifaire indicatif
+
+Template vendu en pack clé en main, entre **2 000 € et 5 000 €** selon le niveau d'adaptation :
+
+- **Pack standard (2 000 €)** : les fichiers tels quels, licence d'usage interne, une heure d'accompagnement à la configuration.
+- **Pack adapté (3 500 €)** : personnalisation du mandat aux conventions collectives et outils ATS de l'organisation.
+- **Pack intégré (5 000 €)** : déploiement dans un runtime AMR Tier 1, connexion ATS, première revue de conformité.
+
+Le template seul ne remplace pas le runtime mandate-gated (Tier 1 AMR, 350 €/mois) ni une validation par un juriste interne. Il pose la structure ; la décision reste humaine.
+
+## À valider côté client avant déploiement
+
+- Revue du mandat par le DPO et le service juridique.
+- Information préalable des candidats (RGPD, article 13 ; Code du travail, article L.1221-9).
+- Mise à jour du registre des traitements.
+- Décision sur la nécessité d'une analyse d'impact (DPIA) au titre de l'article 35 RGPD.

--- a/templates/agent-rh-recrutement/compliance/ai_act_mapping.md
+++ b/templates/agent-rh-recrutement/compliance/ai_act_mapping.md
@@ -1,0 +1,53 @@
+# Cartographie AI Act — Agent RH Recrutement
+
+Référence : **Règlement (UE) 2024/1689** du Parlement européen et du Conseil établissant des règles harmonisées concernant l'intelligence artificielle.
+
+## Classification
+
+Un système d'IA utilisé pour le recrutement, la sélection ou l'évaluation des candidats relève de l'**Annexe III, point 4** du Règlement. À ce titre, il est classé **système à haut risque**.
+
+> Annexe III, point 4 : « Emploi, gestion des travailleurs et accès à l'emploi indépendant », en particulier (a) les systèmes destinés à être utilisés pour le recrutement ou la sélection de personnes physiques, notamment pour publier des offres ciblées, analyser et filtrer les candidatures, et évaluer les candidats.
+
+Cette classification déclenche l'ensemble des obligations du Chapitre III, Section 2 du Règlement.
+
+## Obligations mappées dans `mandate.yaml`
+
+### Article 12 — Tenue de registres
+
+Le système doit enregistrer automatiquement les événements pertinents pendant toute la durée de vie du système à haut risque.
+
+Dans le template : section `audit_trail.logged_events` et `log_retention_days`. La chaîne SHA-256 (`tamper_evidence`) garantit l'intégrité des traces.
+
+### Article 13 — Transparence et information des utilisateurs
+
+Le système doit fournir aux déployeurs des informations claires et complètes sur son fonctionnement.
+
+Dans le template : section `agent.purpose` et `compliance_mapping`. La notice d'information aux candidats reste à la charge du déployeur (cf. `rgpd_mapping.md`).
+
+### Article 14 — Supervision humaine
+
+Les systèmes à haut risque doivent être conçus de façon à permettre une supervision humaine effective, avec la possibilité d'interrompre ou d'annuler une décision.
+
+Dans le template : section `human_oversight` entière. Trois régimes possibles — `human_in_the_loop_strict`, `human_in_the_loop`, `human_on_the_loop` — avec des déclencheurs obligatoires de revue humaine.
+
+### Article 26 — Obligations des déployeurs
+
+Le déployeur doit utiliser le système conformément à la notice, assurer la supervision humaine, tenir les journaux, et informer les personnes concernées lorsqu'il est décidé ou aidé à décider à leur sujet.
+
+Dans le template : cadré par `principal.representative`, `human_oversight.reviewer_profile`, `audit_trail`, `expiration.revocation`.
+
+## Calendrier d'application
+
+Les obligations relatives aux systèmes à haut risque de l'Annexe III s'appliquent à partir du **2 août 2026**, conformément à l'article 113 du Règlement.
+
+Un report partiel via le paquet dit « Digital Omnibus » est discuté au niveau européen à la date de rédaction de ce template. **À suivre au regard des trilogues en cours.** Le mandat reste valable dans les deux hypothèses.
+
+## Sanctions encourues
+
+Article 99 du Règlement : jusqu'à **35 M€ ou 7 % du chiffre d'affaires mondial annuel** pour les manquements les plus graves (pratiques d'IA interdites — article 5). Jusqu'à **15 M€ ou 3 %** pour les manquements aux obligations des systèmes à haut risque.
+
+## Points à valider par un juriste
+
+- Vérifier si le déploiement prévu relève effectivement de l'Annexe III point 4 dans le cas d'usage précis (certains outils purement descriptifs peuvent en être exclus). **À VALIDER PAR JURISTE.**
+- Vérifier la qualité de « déployeur » vs « fournisseur » au sens du Règlement (articles 3 et 25).
+- S'assurer que l'évaluation de conformité et le marquage CE du système fourni ont été réalisés en amont par le fournisseur du modèle.

--- a/templates/agent-rh-recrutement/compliance/rgpd_mapping.md
+++ b/templates/agent-rh-recrutement/compliance/rgpd_mapping.md
@@ -1,0 +1,59 @@
+# Cartographie RGPD — Agent RH Recrutement
+
+Référence : **Règlement (UE) 2016/679** (RGPD) et **Loi n° 78-17 du 6 janvier 1978 modifiée** (Loi Informatique et Libertés).
+
+## Base légale — Article 6
+
+Le template retient l'**intérêt légitime** (article 6(1)(f)) comme base légale par défaut. Cet intérêt consiste à gérer les candidatures reçues et à sélectionner les profils adaptés aux postes à pourvoir.
+
+Le recours à l'intérêt légitime suppose la tenue d'un **test de mise en balance** documenté, qui justifie que l'intérêt du responsable de traitement ne prévaut pas de façon disproportionnée sur les droits et libertés des candidats. **À VALIDER PAR JURISTE** selon le contexte précis.
+
+Dans le template : section `principal.legal_basis_gdpr` et référence `balancing_test_ref`.
+
+## Information des candidats — Article 13
+
+Les candidats doivent être informés, au plus tard au moment de la collecte de leurs données, de l'existence d'un traitement assisté par IA, de sa finalité, de sa base légale, de la durée de conservation, et de leurs droits.
+
+**Le mandat ne dispense pas** de cette information ; il la rend auditable.
+
+## Décision individuelle automatisée — Article 22
+
+L'article 22 interdit, sauf exceptions, la décision produisant des effets juridiques ou affectant significativement la personne lorsqu'elle est fondée **exclusivement** sur un traitement automatisé.
+
+Le template est conçu pour **ne pas tomber** sous l'article 22 : toute décision produisant un effet (rejet, proposition d'entretien, envoi de message) passe par une validation humaine effective, consignée dans le journal d'audit.
+
+Dans le template : `human_oversight.mandatory_review_triggers` et champ `automated_decision_making_article_22: false` dans les exemples.
+
+**Attention** : la CNIL considère que l'intervention humaine doit être *significative*, pas une simple validation automatique. Les reviewers doivent être formés (champ `reviewer_profile.training_required: true`) et avoir le pouvoir effectif de contredire la recommandation de l'agent.
+
+## Analyse d'impact — Article 35
+
+Le recrutement assisté par IA entre typiquement dans les cas où une analyse d'impact (DPIA) est requise : traitement à grande échelle de données personnelles, évaluation de personnes, nouveau type de technologie.
+
+La CNIL a publié une liste des traitements pour lesquels une DPIA est requise (délibération n° 2018-327 du 11 octobre 2018). **À VALIDER** selon la nature exacte du déploiement.
+
+Dans le template : champ `dpia_required: true` dans les exemples.
+
+## Catégories particulières — Article 9
+
+Les données de santé, d'origine raciale ou ethnique, d'opinions politiques, syndicales, religieuses, de vie ou d'orientation sexuelle sont des catégories particulières protégées. **Leur traitement par l'agent est interdit** (champ `data_access.special_categories_article_9: "non_autorise"` du template maître).
+
+Corollaire : les champs CV susceptibles de révéler ces données (photo, date de naissance, situation familiale, état de santé) sont listés dans `fields_forbidden` et ne doivent pas être transmis à l'agent.
+
+## Durée de conservation
+
+Le template propose 90 jours pour les candidatures actives et 730 jours (2 ans) pour les candidatures conservées avec l'accord du candidat. Ces durées reflètent la **recommandation de la CNIL en matière de recrutement** ; elles doivent être validées au regard du référentiel applicable. **À VALIDER PAR JURISTE.**
+
+## Droits des personnes — Articles 15 à 21
+
+Le journal d'audit AMR facilite l'exercice des droits : accès (article 15), rectification (16), effacement (17), limitation (18), portabilité (20), opposition (21).
+
+La procédure de réponse aux demandes reste à la charge du déployeur et ne doit pas excéder un mois (article 12(3)).
+
+## Points à valider par un DPO
+
+- Test de mise en balance pour l'intérêt légitime (article 6(1)(f)).
+- Nécessité d'une DPIA formelle (article 35).
+- Mise à jour du registre des activités de traitement (article 30).
+- Contrat de sous-traitance avec le fournisseur du modèle (article 28) — en particulier sur les transferts hors UE (articles 44 à 49).
+- Information des représentants du personnel si applicable (Code du travail, articles L.2312-38 et L.2312-26).

--- a/templates/agent-rh-recrutement/compliance/sector_specific.md
+++ b/templates/agent-rh-recrutement/compliance/sector_specific.md
@@ -1,0 +1,77 @@
+# Règles sectorielles françaises — Recrutement
+
+En complément de l'AI Act et du RGPD, le déploiement d'un agent IA en recrutement doit respecter le cadre du droit du travail français et les recommandations des autorités compétentes.
+
+## Code du travail — Non-discrimination
+
+### Article L.1132-1
+
+Interdit toute discrimination directe ou indirecte dans l'embauche sur une liste de critères protégés (origine, sexe, âge, état de santé, handicap, opinions, appartenance syndicale, etc.).
+
+Dans le template : section `restrictions.prohibited_criteria` liste les critères sur lesquels l'agent ne peut jamais fonder une recommandation. Cette liste est dérivée de L.1132-1 et de l'article 225-1 du Code pénal.
+
+### Article 225-1 du Code pénal
+
+Définit pénalement la discrimination. Une décision défavorable assistée par un agent qui utiliserait un critère prohibé exposerait l'organisation — et potentiellement les personnes physiques responsables — à des sanctions pénales.
+
+## Code du travail — Transparence et pertinence
+
+### Article L.1221-6
+
+Les informations demandées au candidat ne peuvent avoir comme finalité que d'apprécier sa capacité à occuper l'emploi proposé ou ses aptitudes professionnelles. Elles doivent présenter un **lien direct et nécessaire** avec l'emploi ou les aptitudes professionnelles évaluées.
+
+Dans le template : section `permissions.read.fields_allowed` et `fields_forbidden`.
+
+### Article L.1221-8
+
+Le candidat doit être **expressément informé**, préalablement à leur mise en œuvre, des méthodes et techniques d'aide au recrutement utilisées à son égard.
+
+Implication directe : les candidats doivent être informés de l'existence et de la nature de l'agent IA avant que leur candidature soit traitée. Une simple mention dans la politique de confidentialité n'est probablement pas suffisante. **À VALIDER PAR JURISTE.**
+
+### Article L.1221-9
+
+Aucune information concernant personnellement un candidat ne peut être collectée par un dispositif qui n'a pas été porté préalablement à sa connaissance.
+
+Implication : la configuration de l'agent (périmètre, critères évalués, modèle utilisé) doit être descriptible dans une notice communicable.
+
+## Information des représentants du personnel
+
+### Articles L.2312-38 et L.2312-26 du Code du travail
+
+Le comité social et économique (CSE) est informé et consulté sur les questions intéressant l'organisation du travail et sur l'introduction de nouvelles technologies ayant un impact sur les conditions de travail ou l'emploi.
+
+Le déploiement d'un agent de recrutement entre dans ce champ. Une consultation formelle est recommandée avant mise en production. **À VALIDER PAR JURISTE.**
+
+## CNIL — Référentiels applicables
+
+- **Délibération n° 2019-160 du 21 novembre 2019** portant adoption d'un référentiel relatif aux traitements de données à caractère personnel mis en œuvre aux fins de gestion des activités de ressources humaines.
+- **Recommandations CNIL en matière de recrutement** : principe de pertinence, loyauté de la collecte, information préalable.
+- **Guidance CNIL sur l'IA** (publications 2023-2025) : à suivre pour les mises à jour.
+
+## Défenseur des droits
+
+Le Défenseur des droits peut être saisi par un candidat qui s'estime discriminé. Il dispose de pouvoirs d'enquête et peut demander communication des pièces, y compris **le mandat et les journaux d'audit de l'agent**.
+
+La traçabilité produite par AMR est directement utile dans ce cadre.
+
+## Conventions collectives
+
+Certaines conventions collectives contiennent des dispositions spécifiques sur le recrutement (procédures, priorité de reclassement, etc.). Le mandat doit être relu par le service juridique de l'organisation au regard de la ou des conventions applicables. **À VALIDER PAR JURISTE.**
+
+## Accords collectifs internes
+
+Un accord d'entreprise peut encadrer l'usage de l'IA au-delà des obligations légales. Vérifier l'existence d'un tel accord avant déploiement.
+
+## Secteurs particuliers
+
+### Secteur public
+
+Les administrations publiques sont soumises à des obligations additionnelles : statut général de la fonction publique, principes d'égal accès aux emplois publics, obligations renforcées de motivation des décisions. Un template spécifique au secteur public est recommandé — **non couvert par ce template v1**.
+
+### Secteur bancaire et assurance
+
+Certains postes sont soumis à habilitation (ACPR, AMF). Le tri de candidatures pour ces postes doit respecter les exigences d'honorabilité et de compétence. **Hors périmètre de ce template.**
+
+### Santé
+
+Le recrutement de professionnels de santé implique des vérifications d'inscription aux ordres et d'autorisations d'exercice. **Un template dédié santé est prévu dans la feuille de route AMR.**

--- a/templates/agent-rh-recrutement/deploy_guide.md
+++ b/templates/agent-rh-recrutement/deploy_guide.md
@@ -1,0 +1,71 @@
+# Guide de déploiement — Agent RH Recrutement
+
+Ce guide résume les étapes de mise en production du template dans un registre AMR connecté à un ATS. Il ne remplace pas une revue interne (DPO, juridique, CSE).
+
+## Préalables
+
+- Un registre AMR installé (Tier 0 open-source ou Tier 1 mandate-gated).
+- Un ATS (ou l'outil RH cible) capable d'exposer un webhook ou une API de lecture des candidatures.
+- Un agent IA déjà déployé en interne ou fourni par un prestataire, avec un identifiant stable.
+- Un responsable hiérarchique habilité à signer le mandat (DRH, représentant légal).
+- Un DPO ou référent RGPD disponible pour relire le mandat avant signature.
+
+## Étape 1 — Adapter le template maître
+
+1. Ouvrir `mandate.yaml`.
+2. Remplacer toutes les valeurs entre `< >` par les valeurs de l'organisation.
+3. Choisir le profil de base parmi les trois exemples fournis (`permissif`, `restrictif`, `équilibré`) et fusionner avec le template maître si besoin.
+4. Vérifier la cohérence des volumes (`max_volume_per_day`) avec le flux réel de candidatures.
+5. Faire relire par le DPO.
+
+## Étape 2 — Revue juridique interne
+
+- Vérifier l'applicabilité du régime « haut risque » de l'AI Act (Annexe III, point 4).
+- Documenter le test de mise en balance pour l'intérêt légitime (RGPD, article 6(1)(f)).
+- Décider si une analyse d'impact (DPIA, article 35) est nécessaire.
+- Identifier les conventions collectives et accords d'entreprise applicables.
+- Valider la durée de conservation des journaux au regard de la prescription applicable.
+
+## Étape 3 — Information des parties prenantes
+
+- **Candidats** : mettre à jour la notice d'information (RGPD, article 13 et Code du travail, article L.1221-9) pour mentionner l'existence et la nature de l'agent.
+- **CSE** : consultation formelle si l'organisation en est dotée (Code du travail, articles L.2312-38 et L.2312-26).
+- **Recruteurs** : formation obligatoire aux biais algorithmiques, à la supervision humaine et aux droits des candidats. Consigner la formation dans un registre interne.
+
+## Étape 4 — Chargement du mandat dans AMR
+
+1. Valider le YAML avec un parseur strict (`python -c "import yaml; yaml.safe_load(open('mandate.yaml'))"`).
+2. Signer le mandat : signature interne ou signature électronique eIDAS qualifiée selon la politique de l'organisation.
+3. Charger dans le registre AMR via l'outil `create_mandate`.
+4. Vérifier la présence dans la chaîne avec `audit_mandate_chain`.
+5. Configurer l'agent pour qu'il appelle `verify_mandate` avant toute action sensible.
+
+## Étape 5 — Tests de bout en bout
+
+Avant la mise en production réelle :
+
+- **Test de périmètre** : soumettre une candidature hors périmètre autorisé, vérifier le refus.
+- **Test de volume** : simuler un pic au-delà de `max_volume_per_day`, vérifier le blocage et l'alerte.
+- **Test de supervision** : simuler un score bas, vérifier le déclenchement de la revue humaine obligatoire.
+- **Test de révocation** : révoquer le mandat, vérifier que l'agent cesse immédiatement d'agir.
+- **Test d'audit** : exporter les journaux sur une période courte, vérifier l'intégrité SHA-256.
+
+## Étape 6 — Checklist de validation avant mise en prod
+
+- [ ] Mandat relu et signé par le représentant habilité.
+- [ ] DPO consulté, DPIA réalisée si nécessaire.
+- [ ] CSE informé et, le cas échéant, consulté.
+- [ ] Notice candidats mise à jour et publiée.
+- [ ] Formation des recruteurs effectuée et tracée.
+- [ ] Registre des traitements mis à jour.
+- [ ] Contrat de sous-traitance signé avec le fournisseur du modèle (RGPD, article 28).
+- [ ] Procédure de gestion des demandes d'exercice de droits opérationnelle.
+- [ ] Tests de bout en bout passés.
+- [ ] Date de revue du mandat calée dans un calendrier (tous les 3 à 12 mois selon profil).
+
+## Points d'attention critiques
+
+- **La supervision humaine doit être effective**, pas symbolique. Un reviewer qui valide en masse sans lire les cas sensibles ne remplit pas l'obligation de l'article 14 de l'AI Act.
+- **Toute mise à jour majeure du modèle LLM** doit déclencher la révocation du mandat en cours et la signature d'un nouveau mandat. Un modèle n'est pas une variable libre.
+- **Les transferts hors UE** sont interdits par défaut dans le template. Si le fournisseur du modèle les nécessite, encadrement par clauses contractuelles types et analyse de transfert spécifique (RGPD, articles 44 à 49).
+- **La chaîne d'audit est inutile si personne ne la lit.** Prévoir une revue périodique par l'audit interne, a minima trimestrielle.

--- a/templates/agent-rh-recrutement/examples/01-permissif.yaml
+++ b/templates/agent-rh-recrutement/examples/01-permissif.yaml
@@ -1,0 +1,135 @@
+# Exemple 01 — Mandat PERMISSIF
+# Profil cible : organisation mature, process RH deja rodes,
+# agent deploye en support sur un ATS maitrise, oversight humain
+# renforce par des revues statistiques regulieres.
+#
+# Attention : "permissif" ne veut pas dire "sans garde-fou".
+# Les interdictions legales (non-discrimination, RGPD) restent strictes.
+# C'est le volume et le perimetre fonctionnel qui sont elargis.
+
+metadata:
+  template_id: "amr-tpl-rh-recrutement-v1"
+  profile: "permissif"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-20"
+
+principal:
+  type: "legal_entity"
+  legal_name: "ACME Conseil SAS"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "000000000"
+  representative:
+    name: "Directrice des Ressources Humaines"
+    role: "DRH"
+    email: "drh@acme.example"
+  legal_basis_gdpr:
+    article: "6(1)(f)"
+    description: "Interet legitime — gestion des candidatures"
+
+agent:
+  agent_id: "acme-rh-bot-01"
+  display_name: "Assistant-Recrutement-Groupe"
+  provider: "equipe interne IT"
+  model:
+    family: "Claude"
+    version: "Sonnet 4.6"
+    hosted_in: "EU-West"
+  # Volume eleve : l'agent traite l'ensemble des flux entrants
+  # sur plusieurs marques du groupe.
+  purpose: "Pre-traitement massif de candidatures avant revue humaine."
+
+scope:
+  business_processes:
+    - "tri_candidatures_entrantes"
+    - "extraction_informations_cv"
+    - "scoring_correspondance_poste"
+    - "redaction_messages_candidats"
+    - "planification_entretiens"
+  job_families_covered:
+    - "developpement"
+    - "support"
+    - "commercial"
+    - "marketing"
+    - "operations"
+  geographic_scope:
+    - "FR"
+    - "BE"
+    - "LU"
+  excluded_processes:
+    - "decision_finale_embauche"
+    - "decision_finale_rejet"
+    - "negociation_remuneration"
+
+permissions:
+  read:
+    - resource: "candidatures_ats"
+      # Volume eleve — adapte a un groupe multi-marques.
+      max_volume_per_day: 2000
+      fields_allowed:
+        - "nom"
+        - "prenom"
+        - "cv_texte"
+        - "experiences"
+        - "competences_declarees"
+        - "formations"
+  write:
+    - resource: "notes_internes_ats"
+      max_volume_per_day: 2000
+    - resource: "messages_candidats_templates"
+      # Meme en permissif, tout message sortant passe par une revue.
+      max_volume_per_day: 800
+      requires_human_approval: true
+  invoke:
+    - action: "programmer_entretien"
+      max_per_day: 100
+      requires_human_approval: true
+
+restrictions:
+  forbidden_actions:
+    - "rejeter_candidature_sans_revue_humaine"
+    - "publier_offre_emploi_sans_validation"
+    - "transferer_donnees_hors_UE"
+
+human_oversight:
+  regime: "human_on_the_loop"
+  # "on_the_loop" : l'humain supervise par echantillonnage statistique,
+  # avec declencheurs automatiques sur les cas sensibles.
+  ai_act_reference: "Article 14"
+  mandatory_review_triggers:
+    - trigger: "envoi_message_candidat"
+      threshold: "tout_message_sortant"
+    - trigger: "rejet_candidature"
+      threshold: "toute_recommandation_de_rejet"
+    - trigger: "score_correspondance_inferieur"
+      threshold: 30
+      unit: "pourcentage"
+  sampling_review:
+    frequency: "quotidien"
+    sample_size_percent: 5
+    reviewer_role: "recruteur_senior"
+
+expiration:
+  valid_from: "2026-05-01"
+  valid_until: "2027-04-30"
+  max_duration_months: 12
+
+audit_trail:
+  logged_events:
+    - "lecture_candidature"
+    - "production_score"
+    - "generation_message"
+    - "validation_humaine"
+    - "declenchement_supervision"
+  log_retention_days: 1825
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "high_risk_system"
+    annex: "Annex III, point 4"
+  gdpr:
+    dpia_required: true
+    dpia_reference: "<reference DPIA interne>"

--- a/templates/agent-rh-recrutement/examples/02-restrictif.yaml
+++ b/templates/agent-rh-recrutement/examples/02-restrictif.yaml
@@ -1,0 +1,120 @@
+# Exemple 02 — Mandat RESTRICTIF
+# Profil cible : premiere experimentation, PME/ETI sans DPO dedie,
+# secteur sensible (sante, public, defense). L'agent est cantonne
+# a des taches a faible autonomie, toute action sortante passe par
+# un humain. Volume faible, traces exhaustives.
+
+metadata:
+  template_id: "amr-tpl-rh-recrutement-v1"
+  profile: "restrictif"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-20"
+
+principal:
+  type: "legal_entity"
+  legal_name: "Clinique du Lac SA"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "000000000"
+  representative:
+    name: "Responsable RH"
+    role: "RRH"
+    email: "rh@clinique.example"
+  legal_basis_gdpr:
+    article: "6(1)(f)"
+    description: "Interet legitime — pre-lecture des candidatures"
+
+agent:
+  agent_id: "clinique-rh-bot-01"
+  display_name: "Assistant-Lecture-CV"
+  provider: "prestataire externe certifie"
+  model:
+    family: "Claude"
+    version: "Haiku 4.5"
+    hosted_in: "EU-West"
+  purpose: "Extraction structuree d'informations a partir des CV recus, sans aucune production de message ni planification."
+
+scope:
+  business_processes:
+    # Un seul processus autorise : extraction brute.
+    - "extraction_informations_cv"
+  job_families_covered:
+    - "soignants"
+    - "administratif"
+  geographic_scope:
+    - "FR"
+  excluded_processes:
+    - "decision_finale_embauche"
+    - "decision_finale_rejet"
+    - "redaction_messages_candidats"
+    - "planification_entretiens"
+    - "scoring_correspondance_poste"
+
+permissions:
+  read:
+    - resource: "candidatures_ats"
+      # Volume bas — coherent avec un service RH de taille intermediaire.
+      max_volume_per_day: 50
+      fields_allowed:
+        - "nom"
+        - "prenom"
+        - "cv_texte"
+        - "experiences"
+        - "competences_declarees"
+        - "formations"
+      fields_forbidden:
+        - "photo"
+        - "date_naissance"
+        - "situation_familiale"
+        - "etat_sante"
+  write:
+    # Aucune ecriture autorisee en dehors d'un log interne.
+    - resource: "log_extraction"
+      max_volume_per_day: 50
+  invoke: []
+
+restrictions:
+  forbidden_actions:
+    - "rejeter_candidature_sans_revue_humaine"
+    - "generer_message_candidat"
+    - "programmer_entretien"
+    - "produire_score_automatique"
+    - "publier_offre_emploi"
+    - "transferer_donnees_hors_UE"
+
+human_oversight:
+  regime: "human_in_the_loop_strict"
+  # Chaque extraction produit une fiche qui n'est exploitable
+  # qu'apres validation humaine explicite.
+  ai_act_reference: "Article 14"
+  mandatory_review_triggers:
+    - trigger: "toute_extraction"
+      threshold: "systematique"
+  reviewer_profile:
+    role: "recruteur_habilite"
+    training_required: true
+
+expiration:
+  valid_from: "2026-05-01"
+  # Mandat court : reevalue tous les 3 mois pendant l'experimentation.
+  valid_until: "2026-07-31"
+  max_duration_months: 3
+
+audit_trail:
+  logged_events:
+    - "lecture_candidature"
+    - "extraction_produite"
+    - "validation_humaine"
+    - "rejet_apres_validation"
+  log_retention_days: 1825
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "high_risk_system"
+    annex: "Annex III, point 4"
+  gdpr:
+    dpia_required: true
+    automated_decision_making_article_22: false

--- a/templates/agent-rh-recrutement/examples/03-equilibre.yaml
+++ b/templates/agent-rh-recrutement/examples/03-equilibre.yaml
@@ -1,0 +1,149 @@
+# Exemple 03 — Mandat EQUILIBRE
+# Profil cible : ETI avec une fonction RH structuree, DPO en place,
+# deploiement en production apres une phase pilote restrictive.
+# L'agent a une autonomie moyenne sur les taches routinieres,
+# les actions sortantes restent soumises a revue humaine ciblee.
+
+metadata:
+  template_id: "amr-tpl-rh-recrutement-v1"
+  profile: "equilibre"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-20"
+
+principal:
+  type: "legal_entity"
+  legal_name: "Mandatia Industries SAS"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "000000000"
+  representative:
+    name: "DRH et DPO co-signataires"
+    role: "DRH + DPO"
+    email: "rh-ia@mandatia.example"
+  legal_basis_gdpr:
+    article: "6(1)(f)"
+    description: "Interet legitime — pre-qualification des candidatures"
+
+agent:
+  agent_id: "mandatia-rh-bot-01"
+  display_name: "Assistant-Recrutement-Prod"
+  provider: "prestataire externe"
+  model:
+    family: "Claude"
+    version: "Sonnet 4.6"
+    hosted_in: "EU-West"
+  purpose: "Pre-qualification de bout-en-bout jusqu'a la proposition de creneau d'entretien, toujours sous revue humaine ciblee."
+
+scope:
+  business_processes:
+    - "tri_candidatures_entrantes"
+    - "extraction_informations_cv"
+    - "scoring_correspondance_poste"
+    - "redaction_messages_candidats"
+    - "planification_entretiens"
+  job_families_covered:
+    - "developpement"
+    - "support"
+    - "commercial"
+  geographic_scope:
+    - "FR"
+  excluded_processes:
+    - "decision_finale_embauche"
+    - "decision_finale_rejet"
+    - "negociation_remuneration"
+    - "evaluation_psychometrique_automatisee"
+
+permissions:
+  read:
+    - resource: "candidatures_ats"
+      # Volume intermediaire — 500/jour couvre un service RH actif.
+      max_volume_per_day: 500
+      fields_allowed:
+        - "nom"
+        - "prenom"
+        - "cv_texte"
+        - "experiences"
+        - "competences_declarees"
+        - "formations"
+      fields_forbidden:
+        - "photo"
+        - "date_naissance"
+        - "situation_familiale"
+        - "etat_sante"
+  write:
+    - resource: "notes_internes_ats"
+      max_volume_per_day: 500
+    - resource: "messages_candidats_templates"
+      max_volume_per_day: 200
+      requires_human_approval: true
+  invoke:
+    - action: "programmer_entretien"
+      max_per_day: 30
+      requires_human_approval: true
+
+restrictions:
+  forbidden_actions:
+    - "rejeter_candidature_sans_revue_humaine"
+    - "publier_offre_emploi_sans_validation"
+    - "transferer_donnees_hors_UE"
+    - "entrainer_modele_tiers_sur_donnees_candidats"
+
+human_oversight:
+  regime: "human_in_the_loop"
+  ai_act_reference: "Article 14"
+  mandatory_review_triggers:
+    - trigger: "envoi_message_candidat"
+      threshold: "tout_message_sortant"
+    - trigger: "rejet_candidature"
+      threshold: "toute_recommandation_de_rejet"
+    - trigger: "score_correspondance_inferieur"
+      # Seuil intermediaire — en dessous de 40 %, alerte humaine.
+      threshold: 40
+      unit: "pourcentage"
+    - trigger: "volume_quotidien_traite"
+      threshold: 400
+      unit: "candidatures_par_jour"
+  reviewer_profile:
+    role: "recruteur_habilite"
+    training_required: true
+
+expiration:
+  valid_from: "2026-05-01"
+  valid_until: "2027-04-30"
+  max_duration_months: 12
+  revocation:
+    immediate_triggers:
+      - "incident_de_securite_confirme"
+      - "plainte_candidat_recevable"
+      - "mise_a_jour_majeure_du_modele_llm"
+
+audit_trail:
+  logged_events:
+    - "lecture_candidature"
+    - "production_score"
+    - "generation_message"
+    - "validation_humaine"
+    - "rejet_apres_validation"
+    - "declenchement_supervision"
+  log_retention_days: 1825
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "high_risk_system"
+    annex: "Annex III, point 4"
+    articles:
+      - "Article 12"
+      - "Article 13"
+      - "Article 14"
+      - "Article 26"
+  gdpr:
+    dpia_required: true
+    automated_decision_making_article_22: false
+  national_law_fr:
+    - "Code du travail, article L.1132-1"
+    - "Code du travail, article L.1221-6"
+    - "Code du travail, article L.1221-8"
+    - "Code du travail, article L.1221-9"

--- a/templates/agent-rh-recrutement/mandate.yaml
+++ b/templates/agent-rh-recrutement/mandate.yaml
@@ -1,0 +1,211 @@
+# AMR Mandate Template — Agent RH Recrutement
+# Version 1.0 — langue: fr — juridiction: FR-EU
+# Ce fichier est un gabarit. Les valeurs entre < > doivent être renseignees
+# par l'organisation qui emet le mandat avant chargement dans le registre AMR.
+
+metadata:
+  template_id: "amr-tpl-rh-recrutement-v1"
+  template_version: "1.0.0"
+  domain: "ressources-humaines"
+  subdomain: "recrutement-selection"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-20"
+  reference_standards:
+    - "Regulation (EU) 2024/1689 — AI Act"
+    - "Regulation (EU) 2016/679 — GDPR"
+    - "Code du travail (France) — articles L.1221-6 a L.1221-9"
+
+principal:
+  type: "legal_entity"
+  legal_name: "<Raison sociale du mandant>"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "<SIREN 9 chiffres>"
+  representative:
+    name: "<Nom du representant habilite>"
+    role: "<Fonction — ex: DRH, Directeur juridique>"
+    email: "<email@entreprise.fr>"
+  legal_basis_gdpr:
+    article: "6(1)(f)"
+    description: "Interet legitime — gestion des candidatures et selection"
+    balancing_test_ref: "<reference interne du test de mise en balance>"
+
+agent:
+  agent_id: "<identifiant unique interne de l'agent>"
+  display_name: "<nom fonctionnel — ex: Assistant-Recrutement-Paris>"
+  provider: "<editeur ou equipe interne>"
+  model:
+    family: "<famille — ex: Claude, GPT, Mistral>"
+    version: "<version specifique deployee>"
+    hosted_in: "<zone d'hebergement — ex: EU-West>"
+  purpose: "Assister le recruteur humain dans le tri et la pre-qualification des candidatures, sans decision finale automatisee."
+
+scope:
+  business_processes:
+    - "tri_candidatures_entrantes"
+    - "extraction_informations_cv"
+    - "scoring_correspondance_poste"
+    - "redaction_messages_candidats"
+    - "planification_entretiens"
+  job_families_covered:
+    - "<liste explicite — ex: dev, support, commercial>"
+  geographic_scope:
+    - "FR"
+  excluded_processes:
+    - "decision_finale_embauche"
+    - "decision_finale_rejet"
+    - "negociation_remuneration"
+    - "evaluation_psychometrique_automatisee"
+
+permissions:
+  read:
+    - resource: "candidatures_ats"
+      max_volume_per_day: 500
+      fields_allowed:
+        - "nom"
+        - "prenom"
+        - "cv_texte"
+        - "experiences"
+        - "competences_declarees"
+        - "formations"
+      fields_forbidden:
+        - "photo"
+        - "date_naissance"
+        - "situation_familiale"
+        - "origine"
+        - "religion"
+        - "etat_sante"
+        - "orientation_sexuelle"
+        - "opinions_politiques"
+        - "appartenance_syndicale"
+  write:
+    - resource: "notes_internes_ats"
+      max_volume_per_day: 500
+    - resource: "messages_candidats_templates"
+      max_volume_per_day: 200
+      requires_human_approval: true
+  invoke:
+    - action: "programmer_entretien"
+      max_per_day: 30
+      requires_human_approval: true
+
+restrictions:
+  forbidden_actions:
+    - "rejeter_candidature_sans_revue_humaine"
+    - "publier_offre_emploi_sans_validation"
+    - "contacter_candidat_hors_canaux_autorises"
+    - "transferer_donnees_hors_UE"
+    - "entrainer_modele_tiers_sur_donnees_candidats"
+  prohibited_criteria:
+    description: >
+      L'agent ne peut utiliser aucun critere prohibe par l'article L.1132-1
+      du Code du travail ni par l'article 225-1 du Code penal (discriminations).
+    list:
+      - "age"
+      - "sexe"
+      - "origine"
+      - "situation_familiale"
+      - "apparence_physique"
+      - "patronyme"
+      - "etat_de_sante"
+      - "handicap"
+      - "opinions_politiques_syndicales_religieuses"
+
+data_access:
+  categories:
+    - label: "donnees_identite_candidat"
+      sensitivity: "personal"
+      gdpr_basis: "6(1)(f)"
+    - label: "donnees_professionnelles"
+      sensitivity: "personal"
+      gdpr_basis: "6(1)(f)"
+  special_categories_article_9: "non_autorise"
+  retention:
+    active_candidates_days: 90
+    passive_candidates_days: 730
+    justification: "Alignement avec recommandation CNIL sur la duree de conservation en recrutement — A VALIDER PAR JURISTE en fonction du referentiel applicable."
+  data_minimization: true
+  transfer_outside_eu: false
+
+human_oversight:
+  regime: "human_in_the_loop"
+  ai_act_reference: "Article 14"
+  mandatory_review_triggers:
+    - trigger: "envoi_message_candidat"
+      threshold: "tout_message_sortant"
+    - trigger: "rejet_candidature"
+      threshold: "toute_recommandation_de_rejet"
+    - trigger: "score_correspondance_inferieur"
+      threshold: 40
+      unit: "pourcentage"
+    - trigger: "volume_quotidien_traite"
+      threshold: 400
+      unit: "candidatures_par_jour"
+  reviewer_profile:
+    role: "recruteur_habilite"
+    training_required: true
+    training_topics:
+      - "biais_algorithmiques"
+      - "non_discrimination_recrutement"
+      - "RGPD_droits_candidats"
+
+expiration:
+  valid_from: "<AAAA-MM-JJ>"
+  valid_until: "<AAAA-MM-JJ — 12 mois maximum recommande>"
+  max_duration_months: 12
+  revocation:
+    immediate_triggers:
+      - "incident_de_securite_confirme"
+      - "plainte_candidat_recevable"
+      - "mise_a_jour_majeure_du_modele_llm"
+      - "changement_de_prestataire"
+    revocation_contacts:
+      - "<dpo@entreprise.fr>"
+      - "<drh@entreprise.fr>"
+
+audit_trail:
+  logged_events:
+    - "lecture_candidature"
+    - "production_score"
+    - "generation_message"
+    - "validation_humaine"
+    - "rejet_apres_validation"
+    - "declenchement_supervision"
+  log_retention_days: 1825
+  log_retention_justification: "5 ans — alignement avec duree de prescription en matiere de discrimination — A VALIDER PAR JURISTE."
+  log_access:
+    - "dpo"
+    - "drh"
+    - "audit_interne"
+    - "autorite_de_controle_sur_requisition"
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "high_risk_system"
+    annex: "Annex III, point 4 — emploi, gestion de la main-d'oeuvre"
+    articles:
+      - "Article 12 — tenue de registres"
+      - "Article 13 — transparence vis-a-vis des utilisateurs"
+      - "Article 14 — supervision humaine"
+      - "Article 26 — obligations des deployeurs"
+  gdpr:
+    articles:
+      - "Article 6 — base legale"
+      - "Article 13 — information des personnes"
+      - "Article 22 — decision individuelle automatisee"
+      - "Article 35 — analyse d'impact"
+  national_law_fr:
+    - "Code du travail, article L.1132-1 — non-discrimination"
+    - "Code du travail, article L.1221-6 — pertinence des informations demandees"
+    - "Code du travail, article L.1221-8 — information du candidat"
+    - "Code du travail, article L.1221-9 — methodes et techniques d'evaluation"
+    - "Loi Informatique et Libertes, article 47 — controle humain sur decision"
+
+signature:
+  method: "<eIDAS qualifie | avance | interne>"
+  signed_at: "<AAAA-MM-JJ>"
+  signatory: "<nom et fonction>"
+  signature_ref: "<reference de la signature ou hash>"


### PR DESCRIPTION
Premier template sectoriel Tier 3 (Agent RH Recrutement) : README FR, mandate.yaml, 3 exemples (permissif/restrictif/équilibré), cartographie AI Act + RGPD + droit du travail FR, guide de déploiement.
Valeur business : pack vendable 2 000–5 000 € dès qu'un premier prospect RH demande un cadre concret ; démontre aussi la crédibilité juridique d'AMR auprès des Design Partners.
À valider humainement : relecture par un juriste (durées de conservation à 5 ans, test de mise en balance article 6(1)(f), applicabilité exacte Annexe III), cohérence de la voix avec les autres pages du site.
Effort Audric pour merger : 5–10 min de parcours rapide pour valider ton / couverture, relecture juridique peut venir après merge avant premier pitch commercial.

## Auto-check

1. **Utilisable / vendable en l'état ?** Oui comme support de démonstration et première base de négociation. Avant facturation à un premier client, une relecture juriste d'une heure reste prudente — surtout sur les durées de conservation et la DPIA.
2. **Ce qu'un juriste expert corrigerait en premier ?** La durée de rétention des journaux à 5 ans (alignée sur la prescription discrimination) et la documentation du test de mise en balance pour l'intérêt légitime. La formulation « l'article 22 ne s'applique pas » bénéficierait d'une justification plus étayée par cas d'usage.
3. **30 % à couper sans perte ?** Quelques redondances entre `README.md` (section risques) et `compliance/*.md` ; certains paragraphes du guide de déploiement recoupent la checklist. Le fond reste dense en références précises, donc peu de gras réel.