### PR TITLE
[Ship] Template — Agent Support Client v1

### DIFF
--- a/templates/agent-support-client/README.md
+++ b/templates/agent-support-client/README.md
@@ -1,0 +1,62 @@
+# Template AMR — Agent Support Client
+
+Template de mandat prêt à l'emploi pour encadrer un agent IA déployé en support client (traitement de tickets entrants, réponse de premier niveau, escalade, remboursement de faible montant, mise à jour de données non sensibles).
+
+## Pour qui
+
+- Directions de la relation client d'ETI et grands comptes qui testent un agent conversationnel en production.
+- Responsables conformité et DPO qui doivent cadrer un déploiement déjà en cours sur Zendesk, Intercom, Salesforce Service Cloud ou équivalent.
+- Éditeurs et intégrateurs qui proposent un agent à leurs clients et doivent livrer une gouvernance traçable avec le runtime.
+
+## Contexte
+
+Un agent de support client est rarement classé « à haut risque » au sens de l'AI Act — il ne décide pas d'un emploi, d'un crédit ni d'un droit social. Mais il touche à des données personnelles à grande échelle, à des engagements contractuels (remboursements, avoirs, modifications d'abonnement) et à l'image de l'entreprise.
+
+Deux régimes se superposent :
+
+- L'**article 50 du Règlement (UE) 2024/1689** impose d'informer la personne qu'elle interagit avec un système d'IA, sauf si c'est manifeste par le contexte. La date d'application est fixée au **2 août 2026** (article 113).
+- Le **Règlement (UE) 2016/679 (RGPD)** encadre le traitement des données du client, sa durée de conservation, et l'obligation d'information (articles 12 à 14).
+- Le **Code de la consommation** français encadre les pratiques commerciales : une promesse faite par l'agent (remboursement, délai, geste commercial) engage juridiquement l'entreprise au titre de l'article L.121-1 et suivants.
+
+Déployer un agent de support sans mandat explicite, c'est laisser la machine prendre des engagements commerciaux sans borne chiffrée, sans journal opposable, et sans point d'arrêt en cas de dérive.
+
+## Trois exemples de déploiement concret
+
+1. **Premier niveau conversationnel** : l'agent reçoit les tickets entrants (chat, email), qualifie la demande, répond aux questions de FAQ, et escalade vers un humain tout ce qui sort de son périmètre. Aucun engagement chiffré n'est pris sans validation.
+2. **Gestes commerciaux bornés** : l'agent peut proposer un avoir ou un remboursement en dessous d'un seuil (par exemple 30 €), après vérification de l'historique client. Au-delà, escalade obligatoire.
+3. **Mise à jour de données non sensibles** : l'agent met à jour une adresse de livraison, un numéro de téléphone ou une préférence de communication, à la demande explicite et tracée du client authentifié. Les données bancaires et l'email principal sont exclus.
+
+## Ce que ce template fournit
+
+- `mandate.yaml` : le mandat structuré prêt à charger dans un registre AMR, avec périmètre d'action, plafonds financiers, restrictions explicites, seuils d'escalade, durée de validité, cartographie RGPD et AI Act article 50.
+- `examples/` : trois variantes (permissive, restrictive, équilibrée) commentées, pour s'adapter à la maturité et au niveau de risque de l'organisation.
+- `compliance/` : trois fiches courtes qui cartographient le mandat avec l'AI Act (article 50 transparence), le RGPD (information, minimisation, conservation) et le Code de la consommation français.
+- `deploy_guide.md` : checklist de mise en production et points d'attention sur l'intégration avec un outil de ticketing.
+
+## Pourquoi c'est risqué sans mandat
+
+Un agent de support client sans mandat documenté expose l'organisation à plusieurs risques concrets :
+
+- **Engagement commercial non borné** : une promesse hallucinée (« votre commande sera remboursée en totalité ») peut être opposée à l'entreprise au titre de l'article 1103 du Code civil et des articles L.121-1 et suivants du Code de la consommation.
+- **Sanctions RGPD** : jusqu'à **20 M€ ou 4 %** du chiffre d'affaires mondial en cas de défaut d'information (articles 12, 13) ou de conservation excessive (article 5(1)(e) et article 83).
+- **Sanctions AI Act article 50** : jusqu'à **15 M€ ou 3 %** du chiffre d'affaires mondial pour défaut d'information sur l'interaction avec une IA (article 99, paragraphe 4).
+- **Dérive réputationnelle** : un échange public viral d'un agent promettant n'importe quoi coûte plus cher, sur la durée, qu'une amende.
+
+Le mandat AMR ne supprime pas ces risques — il les **borne** (plafonds chiffrés) et les **documente** (journal opposable).
+
+## Positionnement tarifaire indicatif
+
+Template vendu en pack clé en main, entre **2 000 € et 5 000 €** selon le niveau d'adaptation :
+
+- **Pack standard (2 000 €)** : les fichiers tels quels, licence d'usage interne, une heure d'accompagnement à la configuration.
+- **Pack adapté (3 500 €)** : personnalisation aux conditions générales de vente, aux tarifs de l'entreprise et à l'outil de ticketing en place.
+- **Pack intégré (5 000 €)** : déploiement dans un runtime AMR Tier 1, connexion à l'outil ticket, première revue de conformité.
+
+Le template seul ne remplace pas le runtime mandate-gated (Tier 1 AMR, 350 €/mois) ni une validation par un juriste interne. Il pose la structure ; la décision d'engager l'entreprise reste humaine au-delà des seuils.
+
+## À valider côté client avant déploiement
+
+- Revue du mandat par le DPO et le service juridique.
+- Mise à jour de la notice d'information client (RGPD, article 13) indiquant l'usage d'un agent IA (AI Act, article 50).
+- Ajustement des plafonds financiers aux conditions générales de vente et aux délégations de signature internes.
+- Formation des agents humains de niveau 2 aux cas d'escalade.

--- a/templates/agent-support-client/compliance/ai_act_mapping.md
+++ b/templates/agent-support-client/compliance/ai_act_mapping.md
@@ -1,0 +1,48 @@
+# Cartographie AI Act — Agent Support Client
+
+Référence : **Règlement (UE) 2024/1689** du Parlement européen et du Conseil établissant des règles harmonisées concernant l'intelligence artificielle.
+
+## Classification
+
+Un agent conversationnel de support client de premier niveau n'est pas, en règle générale, listé à l'**Annexe III** du Règlement. Il ne décide ni d'un emploi, ni d'un crédit, ni d'un droit social, ni d'une prestation essentielle. À ce titre, il ne relève **pas** du régime des systèmes à haut risque du Chapitre III, Section 2.
+
+Il relève en revanche de l'**article 50 du Règlement**, qui impose des obligations de transparence pour les systèmes d'IA « destinés à interagir directement avec des personnes physiques ».
+
+## Obligation principale — Article 50
+
+> Article 50, paragraphe 1 : « Les fournisseurs veillent à ce que les systèmes d'IA destinés à interagir directement avec des personnes physiques soient conçus et développés de manière à ce que les personnes physiques concernées soient informées qu'elles interagissent avec un système d'IA, sauf si cela est évident pour une personne physique raisonnablement bien informée, attentive et avisée. »
+
+Dans le template : section `agent.user_disclosure`, champ `disclosure_text_fr` et `disclosure_channels`. L'événement d'affichage de la notice est journalisé (`audit_trail.logged_events : disclosure_ai_act_article_50_affichee`).
+
+## Obligation complémentaire — Article 14 (principe général)
+
+Bien que non formellement obligatoire hors haut risque, le principe de supervision humaine de l'article 14 est transposé dans la section `human_oversight` pour deux raisons :
+
+1. Limiter l'engagement commercial de l'entreprise (Code civil, article 1103).
+2. Protéger les personnes vulnérables (détresse manifeste, réclamation, exercice des droits RGPD).
+
+Trois régimes possibles sont proposés : `human_in_the_loop` (pilote, chaque réponse validée), `human_on_the_loop` (production, revue par échantillonnage statistique) et des déclencheurs automatiques d'escalade.
+
+## Calendrier d'application
+
+Les obligations de l'article 50 s'appliquent à partir du **2 août 2026**, conformément à l'article 113 du Règlement. Cette date n'est pas concernée par les discussions de report actuellement en cours sur le paquet dit « Digital Omnibus », qui portent principalement sur les systèmes à haut risque de l'Annexe III. **À suivre au regard des trilogues en cours.**
+
+## Sanctions encourues
+
+Article 99, paragraphe 4 : jusqu'à **15 M€ ou 3 % du chiffre d'affaires mondial annuel**, le montant le plus élevé étant retenu, pour les manquements aux obligations applicables aux fournisseurs ou aux déployeurs, y compris l'article 50.
+
+## Rôle du déployeur vs fournisseur
+
+L'article 50 impose l'obligation au **fournisseur** du système (celui qui conçoit et met sur le marché). Toutefois, le **déployeur** (l'entreprise qui exploite l'agent) reste responsable au titre de l'article 26 du Règlement de l'utilisation conforme, notamment :
+
+- S'assurer que la notice de transparence est bien affichée dans son intégration (canal web, email, messagerie instantanée).
+- Former les équipes humaines à reprendre la main quand l'agent escalade.
+- Tenir à jour les journaux de fonctionnement.
+
+Dans le template : la responsabilité du déployeur est matérialisée par `principal.representative`, `human_oversight.reviewer_profile`, et `audit_trail`.
+
+## Points à valider par un juriste
+
+- Confirmer que le cas d'usage ne bascule pas dans l'Annexe III par un effet de bord (exemple : si l'agent décide d'accorder ou refuser un crédit, il relève de l'Annexe III point 5 ; si l'agent évalue l'éligibilité à une prestation sociale, il relève du point 5.a). **À VALIDER PAR JURISTE.**
+- Confirmer la qualité de « déployeur » au sens du Règlement (articles 3 et 25) et la répartition des responsabilités avec le fournisseur du modèle.
+- Vérifier que la notice de transparence est bien rendue visible et pas dissimulée dans des conditions générales.

--- a/templates/agent-support-client/compliance/rgpd_mapping.md
+++ b/templates/agent-support-client/compliance/rgpd_mapping.md
@@ -1,0 +1,68 @@
+# Cartographie RGPD — Agent Support Client
+
+Référence : **Règlement (UE) 2016/679** du Parlement européen et du Conseil relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel (RGPD).
+
+## Base légale du traitement
+
+La base légale retenue dans le template est l'**article 6, paragraphe 1, point b)** — traitement nécessaire à l'exécution du contrat auquel la personne concernée est partie. C'est le fondement naturel pour un agent qui traite une demande client portant sur un produit ou un service souscrit.
+
+Une base alternative sur l'**article 6, paragraphe 1, point f)** (intérêt légitime) est documentée dans le gabarit pour les cas périphériques (amélioration du service, contrôle qualité). Cette base secondaire impose un **test de mise en balance** documenté entre l'intérêt du responsable de traitement et les droits et libertés de la personne concernée.
+
+## Information des personnes — Articles 12 à 14
+
+L'article 13 du RGPD impose d'informer la personne au moment de la collecte. Le template distingue deux niveaux d'information :
+
+1. **Notice RGPD complète** : hébergée dans la politique de confidentialité du site, accessible à tout moment. Responsabilité du déployeur. Elle inclut les finalités, la base légale, la durée de conservation, les droits, le DPO.
+2. **Notice courte « agent IA »** : affichée en ouverture de conversation, au titre de l'article 50 du Règlement (UE) 2024/1689. Elle signale l'interaction avec un système d'IA et l'option d'escalade humaine.
+
+Dans le template : section `agent.user_disclosure` pour la notice courte. La notice RGPD longue n'est pas dans le mandat — elle relève de la politique générale du déployeur.
+
+## Minimisation — Article 5, paragraphe 1, point c)
+
+Le mandat liste explicitement les champs autorisés en lecture (`permissions.read.fields_allowed`) et les champs interdits (`fields_forbidden`). Les données bancaires en clair, les mots de passe, les données de santé, les opinions politiques et religieuses sont exclues par principe. Les champs non nécessaires au traitement de la demande sont absents du mandat.
+
+## Limitation de conservation — Article 5, paragraphe 1, point e)
+
+Trois durées sont distinguées :
+
+- **Ticket actif** : 90 jours après fermeture, pour permettre la reprise d'un échange.
+- **Ticket clos archivé** : 1095 jours (3 ans), alignement avec la prescription commerciale de l'**article 2224 du Code civil**.
+- **Journaux techniques d'audit** : 1095 jours, même justification.
+
+**À VALIDER PAR JURISTE** : certains secteurs (assurance, banque, télécoms avec clients vulnérables) imposent des durées plus longues au titre de règles sectorielles. Le gabarit fixe 3 ans comme plancher raisonnable.
+
+## Sécurité du traitement — Article 32
+
+Le template prévoit :
+
+- Chaîne SHA-256 sur les journaux (`audit_trail.tamper_evidence: sha256_chain`) pour garantir l'intégrité.
+- Accès aux journaux restreint à quatre rôles nominatifs.
+- Interdiction de transfert hors UE (`restrictions.forbidden_actions`).
+- Interdiction d'entraîner un modèle tiers sur les conversations clients.
+
+## Décision automatisée — Article 22
+
+L'agent de support client tel que cadré par ce template **ne produit pas** de décision automatisée produisant des effets juridiques ou affectant significativement la personne, dès lors que :
+
+- Tout geste commercial au-delà du plafond passe par un humain.
+- Toute résiliation est exclue du périmètre.
+- Toute modification de données bancaires est exclue du périmètre.
+
+Si le périmètre évolue (par exemple : l'agent décide unilatéralement d'un refus de remboursement), l'article 22 devient applicable et déclenche l'obligation de garantir à la personne le droit d'obtenir une intervention humaine et de contester la décision.
+
+## Analyse d'impact — Article 35
+
+**DPIA non obligatoire a priori** pour le périmètre du gabarit. Elle devient obligatoire en cas de :
+
+- Traitement à grande échelle de données sensibles (article 9).
+- Évaluation systématique produisant des effets juridiques.
+- Combinaison avec d'autres critères de la liste CNIL des traitements soumis à DPIA.
+
+**À VALIDER PAR DPO** au regard du périmètre exact du déploiement.
+
+## Points à valider par un juriste
+
+- Vérifier l'articulation du test de mise en balance si la base légale secondaire (intérêt légitime) est retenue.
+- Valider la durée de conservation au regard des règles sectorielles applicables.
+- Vérifier la rédaction de la notice RGPD longue et la cohérence avec la notice courte article 50.
+- Confirmer que l'agent ne bascule pas sous l'article 22 par effet de bord.

--- a/templates/agent-support-client/compliance/sector_specific.md
+++ b/templates/agent-support-client/compliance/sector_specific.md
@@ -1,0 +1,52 @@
+# Règles sectorielles — Agent Support Client
+
+Ce document liste les règles additionnelles à vérifier selon le secteur d'activité du déployeur. Le gabarit de mandat est secteur-neutre ; il doit être complété par les obligations sectorielles applicables.
+
+## Principe transversal — Droit commun
+
+Deux règles s'appliquent quel que soit le secteur :
+
+- **Article 1103 du Code civil** : « Les contrats légalement formés tiennent lieu de loi à ceux qui les ont faits. » Toute promesse tenue par l'agent (remboursement, délai, geste commercial) engage l'entreprise comme si elle avait été faite par un conseiller humain. Le mandat borne cet engagement par des plafonds chiffrés (`permissions.invoke.max_amount_eur`).
+- **Article L.121-1 du Code de la consommation** : interdiction des pratiques commerciales déloyales. Un agent qui dissimulerait sa nature d'IA, ou qui tiendrait des propos trompeurs sur les caractéristiques d'un service, exposerait l'entreprise à une sanction pénale (article L.132-2 du même code).
+
+## E-commerce et vente à distance
+
+- **Article L.221-18 du Code de la consommation** : droit de rétractation de 14 jours pour les contrats conclus à distance. L'agent doit informer clairement le client qui en fait la demande.
+- **Article L.111-1 du Code de la consommation** : obligation précontractuelle d'information sur les caractéristiques essentielles du bien ou service, le prix, la durée du contrat.
+- **À VALIDER PAR JURISTE** si l'agent négocie des délais ou des réductions : bien cadrer l'offre et éviter l'ambiguïté sur le prix final.
+
+## Services financiers et assurance
+
+- **Code monétaire et financier, article L.533-11** : obligation de conseil adapté pour les prestataires de services d'investissement. Un agent ne peut formuler un conseil personnalisé sans supervision humaine.
+- **Code des assurances, article L.521-1** : devoir d'information et de conseil de l'intermédiaire d'assurance. Interdiction de déléguer ce devoir à un agent non supervisé.
+- **Règlement (UE) 2022/2554 (DORA)** applicable depuis janvier 2025 : exigences de résilience opérationnelle numérique, notamment sur la gestion des tiers TIC. Si le modèle LLM est hébergé par un tiers, il peut entrer dans le périmètre DORA.
+- **Recommandation ACPR 2023-R-01 relative à la gouvernance des algorithmes** : à intégrer dans le mandat sous forme de points de contrôle humains.
+- **Exemple 02 « restrictif »** : profil recommandé pour un premier déploiement dans ce secteur.
+
+## Télécoms
+
+- **Code des postes et communications électroniques, articles L.44 et suivants** : portabilité du numéro, changement d'opérateur — tout acte contractuel de résiliation ou portage doit être exclu du périmètre de l'agent, ce que fait le gabarit (`scope.excluded_processes`).
+- **Arcep, décision n° 2020-1472** : règles relatives à la qualité de service — si l'agent formule un engagement sur un délai de raccordement, le respecter devient opposable.
+
+## Santé (hors cas HDS direct, traité par le template santé)
+
+- Si l'agent de support renvoie vers un professionnel de santé ou un parcours de soins, il ne doit pas formuler de conseil médical. Une clause explicite dans `restrictions.forbidden_actions` est recommandée : `"formuler_conseil_medical"`.
+- **Code de la santé publique, article L.1111-2** : droit d'information du patient. L'agent ne se substitue pas à cette obligation, il ne fait que rediriger.
+
+## Clients vulnérables — transversal
+
+- **Code de la consommation, article L.121-21** : protection renforcée des consommateurs vulnérables. L'agent doit disposer d'un déclencheur de détresse et escalader immédiatement (`human_oversight.mandatory_escalation_triggers : client_manifeste_detresse`).
+- **Charte de bonne conduite des conseillers numériques** (référentiel informel mais opposable en contentieux) : proscrire toute manipulation émotionnelle, toute urgence fabriquée, toute promotion commerciale auprès d'un client en difficulté manifeste.
+
+## Secteur public et services essentiels
+
+Si l'agent intervient pour le compte d'une personne publique ou d'un opérateur de services essentiels :
+
+- **Directive (UE) 2022/2555 (NIS 2)** transposée par la loi n° 2024-364 : obligations de sécurité renforcées, notification d'incidents.
+- **Code des relations entre le public et l'administration, article L.311-3-1** : obligation d'information sur l'usage d'un traitement algorithmique fondant une décision individuelle. Si l'agent intervient dans une décision administrative, l'article 50 de l'AI Act ne suffit pas — il faut aussi se conformer à cet article national.
+
+## Points à valider par un juriste
+
+- Confirmer le rattachement sectoriel du déploiement (un acteur e-commerce peut être aussi soumis à DORA s'il propose du paiement fractionné).
+- Lister les régulateurs sectoriels à informer en cas d'incident (CNIL, Arcep, ACPR, DGCCRF, ANSSI selon les cas).
+- Vérifier les obligations de transparence renforcée au-delà de l'article 50 de l'AI Act (secteur public notamment).

--- a/templates/agent-support-client/deploy_guide.md
+++ b/templates/agent-support-client/deploy_guide.md
@@ -1,0 +1,36 @@
+# Guide de déploiement — Agent Support Client
+
+## Ordre de mise en production
+
+1. **Cadrage avec le métier** : choisir le profil (permissif, restrictif, équilibré) en fonction du secteur et de la maturité. En première itération, choisir le profil restrictif ou équilibré. Le profil permissif se déverrouille après un retour d'expérience documenté.
+2. **Renseignement du `mandate.yaml`** : remplacer toutes les valeurs entre `< >` par les données réelles de l'organisation (SIREN, représentant, agent, plafonds, canaux de disclosure).
+3. **Revue DPO et juridique** : validation des points marqués « À VALIDER PAR JURISTE » dans les trois fiches de conformité, vérification que la base légale RGPD choisie est adaptée au cas d'usage, vérification des durées de conservation sectorielles.
+4. **Chargement dans le registre AMR** : import du mandat dans le runtime Tier 1. Le token d'exécution de l'agent ne sera émis que si le mandat est valide, signé et non expiré.
+5. **Intégration au canal client** : insertion de la notice de transparence article 50 en ouverture de conversation (chat web, email automatique, messagerie instantanée). La notice doit être journalisée à chaque affichage.
+6. **Formation des équipes niveau 2** : sur les cas d'escalade, la reprise de conversation, la reconnaissance de détresse, le traitement d'une demande RGPD.
+7. **Mise en production en mode pilote** : `human_in_the_loop` pendant au minimum 4 semaines, avec revue humaine systématique des réponses sortantes. Bascule vers `human_on_the_loop` sur décision formelle du comité.
+8. **Revue périodique** : trimestrielle a minima, avec examen des journaux, des incidents, des réclamations, et ajustement des plafonds si nécessaire.
+
+## Points d'attention critiques
+
+- **La notice de transparence doit être visible, pas dissimulée.** Elle s'affiche au début de la conversation, pas dans un lien en pied de page. Un manquement sur ce point expose à l'article 99, paragraphe 4 du Règlement (UE) 2024/1689 : jusqu'à 15 M€ ou 3 % du chiffre d'affaires mondial.
+- **Les plafonds financiers doivent être cohérents avec les délégations de signature internes.** Un agent ne peut pas avoir plus d'autonomie financière qu'un conseiller humain de même niveau.
+- **L'agent ne doit pas nier être une IA si on le lui demande.** Cette règle est explicitée dans `restrictions.prohibited_behaviours`. Un défaut sur ce point cumule une sanction AI Act article 50 et une sanction au titre du Code de la consommation article L.121-2 (pratique commerciale trompeuse).
+- **Aucune donnée bancaire en clair ne doit transiter par l'agent.** Interdit par `permissions.read.fields_forbidden`. La modification de ces données passe par un canal séparé et authentifié.
+- **Toute montée en volume déclenche une réévaluation de la DPIA.** La DPIA n'est pas obligatoire a priori sur le périmètre du gabarit, mais un passage à 10 000 conversations par jour avec profiling peut suffire à basculer sous l'article 35 du RGPD.
+- **L'expiration du mandat doit être surveillée.** Le runtime AMR Tier 1 refuse d'émettre un token pour un mandat expiré. Prévoir une alerte à J-30 pour relancer le processus de renouvellement.
+
+## Checklist de validation avant mise en prod
+
+- [ ] `mandate.yaml` rempli, sans aucune valeur entre `< >` restante.
+- [ ] Signature du mandat par le représentant habilité (méthode eIDAS avancée ou qualifiée recommandée pour les secteurs régulés).
+- [ ] Revue DPO signée.
+- [ ] Revue juridique signée, avec décision explicite sur la nécessité d'une DPIA.
+- [ ] Notice de transparence article 50 intégrée dans tous les canaux listés (`agent.user_disclosure.disclosure_channels`).
+- [ ] Politique de confidentialité mise à jour et publiée.
+- [ ] Formation niveau 2 réalisée, liste des personnes formées annexée.
+- [ ] Période de pilote `human_in_the_loop` planifiée sur au moins 4 semaines.
+- [ ] Plan de revue trimestrielle formalisé (qui, quand, quoi).
+- [ ] Procédure de révocation d'urgence testée (un exercice au moins avant mise en prod).
+- [ ] Journal d'audit connecté à un stockage non modifiable avec chaîne SHA-256 active.
+- [ ] Numéro et adresse du DPO accessibles depuis la conversation à la demande du client.

--- a/templates/agent-support-client/examples/01-permissif.yaml
+++ b/templates/agent-support-client/examples/01-permissif.yaml
@@ -1,0 +1,137 @@
+# Exemple 01 — Mandat PERMISSIF
+# Profil cible : e-commerce mature, volumes eleves, plafonds financiers
+# un peu plus larges, supervision humaine par echantillonnage statistique.
+#
+# "Permissif" ne veut pas dire "sans garde-fou". Les obligations de
+# transparence (AI Act article 50) et d'information (RGPD article 13)
+# restent integrales. Ce sont les volumes et les plafonds qui sont elargis.
+
+metadata:
+  template_id: "amr-tpl-support-client-v1"
+  profile: "permissif"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-21"
+
+principal:
+  type: "legal_entity"
+  legal_name: "ACME Retail SAS"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "000000000"
+  representative:
+    name: "Directrice Relation Client"
+    role: "DRC"
+    email: "drc@acme.example"
+  legal_basis_gdpr:
+    article: "6(1)(b)"
+    description: "Execution du contrat client"
+
+agent:
+  agent_id: "acme-support-bot-01"
+  display_name: "Assistant-Support-Groupe"
+  provider: "equipe interne IT"
+  model:
+    family: "Claude"
+    version: "Sonnet 4.6"
+    hosted_in: "EU-West"
+  purpose: "Support niveau 1 en volume, avec gestes commerciaux bornes."
+  user_disclosure:
+    ai_act_article_50: true
+    # Disclosure systematique, affichee en debut de chaque conversation.
+    disclosure_text_fr: "Vous echangez avec l'assistant virtuel ACME. Tapez 'humain' a tout moment pour etre mis en relation avec un conseiller."
+    disclosure_channels:
+      - "chat_web"
+      - "email_automatique"
+      - "messagerie_instantanee"
+
+scope:
+  business_processes:
+    - "reponse_questions_faq"
+    - "qualification_demande_entrante"
+    - "consultation_historique_client"
+    - "mise_a_jour_donnees_non_sensibles"
+    - "geste_commercial_borne"
+    - "escalade_vers_humain"
+  product_perimeter:
+    - "abonnement_standard"
+    - "abonnement_premium"
+    - "vente_unitaire"
+  geographic_scope:
+    - "FR"
+    - "BE"
+    - "LU"
+  languages_supported:
+    - "fr"
+  excluded_processes:
+    - "resiliation_contractuelle"
+    - "modification_donnees_bancaires"
+
+permissions:
+  read:
+    - resource: "historique_client"
+      # Volume eleve — site grand public.
+      max_volume_per_day: 8000
+  write:
+    - resource: "reponse_client"
+      max_volume_per_day: 6000
+      max_tokens_per_response: 1500
+  invoke:
+    - action: "emettre_avoir"
+      # Plafond releve a 50 euros en profil permissif.
+      max_amount_eur: 50
+      max_per_customer_per_year: 3
+      max_per_day_global: 200
+      requires_human_approval_above_threshold: true
+    - action: "emettre_remboursement"
+      max_amount_eur: 50
+      max_per_customer_per_year: 3
+      max_per_day_global: 150
+      requires_human_approval_above_threshold: true
+
+restrictions:
+  forbidden_actions:
+    - "promettre_delai_hors_cgv"
+    - "resilier_contrat"
+    - "modifier_donnees_bancaires"
+
+human_oversight:
+  regime: "human_on_the_loop"
+  ai_act_reference: "Article 50"
+  # Supervision par echantillonnage plutot qu'a chaque interaction.
+  sampling_review:
+    frequency: "quotidien"
+    sample_size_percent: 3
+    reviewer_role: "superviseur_niveau_2"
+  mandatory_escalation_triggers:
+    - trigger: "demande_remboursement_au_dessus_plafond"
+      threshold: 50
+      unit: "euros"
+    - trigger: "client_manifeste_detresse"
+      threshold: "mot_cle_detecte"
+    - trigger: "demande_exercice_droits_rgpd"
+      threshold: "toute_demande"
+
+expiration:
+  valid_from: "2026-05-01"
+  valid_until: "2027-04-30"
+  max_duration_months: 12
+
+audit_trail:
+  logged_events:
+    - "ouverture_conversation"
+    - "disclosure_ai_act_article_50_affichee"
+    - "generation_reponse"
+    - "geste_commercial_emis"
+    - "escalade_humaine"
+  log_retention_days: 1095
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "limited_risk_transparency_obligation"
+    annex: "non_applicable_annex_III"
+  gdpr:
+    dpia_required: false
+    # Pas de DPIA requise a priori, mais a reevaluer selon volumes et finalites.

--- a/templates/agent-support-client/examples/02-restrictif.yaml
+++ b/templates/agent-support-client/examples/02-restrictif.yaml
@@ -1,0 +1,147 @@
+# Exemple 02 — Mandat RESTRICTIF
+# Profil cible : secteur regule ou sensible (assurance, banque,
+# sante non-HDS, telecoms avec clients vulnerables), premier deploiement,
+# tolerance a la derive quasi nulle.
+#
+# L'agent informe, oriente, rassure. Il n'engage pas l'entreprise
+# financierement. Tout geste commercial passe par un humain.
+
+metadata:
+  template_id: "amr-tpl-support-client-v1"
+  profile: "restrictif"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-21"
+
+principal:
+  type: "legal_entity"
+  legal_name: "Mutuelle Prudente SA"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "000000000"
+  representative:
+    name: "Directeur Relation Adherents"
+    role: "DRA"
+    email: "dra@mutuelle.example"
+  legal_basis_gdpr:
+    article: "6(1)(b)"
+    description: "Execution du contrat d'adhesion"
+
+agent:
+  agent_id: "mutuelle-support-bot-01"
+  display_name: "Assistant-Information-Adherents"
+  provider: "editeur tiers"
+  model:
+    family: "Mistral"
+    version: "Large 2506"
+    hosted_in: "EU-West"
+  purpose: "Repondre aux questions d'information generales des adherents, orienter vers un conseiller humain pour toute demande contractuelle ou financiere."
+  user_disclosure:
+    ai_act_article_50: true
+    # Formulation renforcee : mentionne la limite d'autonomie de l'agent.
+    disclosure_text_fr: "Vous echangez avec un assistant virtuel d'information. Toute demande contractuelle, financiere ou personnelle est transmise a un conseiller humain."
+    disclosure_channels:
+      - "chat_web"
+      - "email_automatique"
+
+scope:
+  business_processes:
+    - "reponse_questions_faq"
+    - "orientation_vers_service"
+    - "escalade_vers_humain"
+  product_perimeter:
+    - "information_generale"
+  geographic_scope:
+    - "FR"
+  languages_supported:
+    - "fr"
+  excluded_processes:
+    - "resiliation_contractuelle"
+    - "modification_donnees_bancaires"
+    - "geste_commercial"
+    - "mise_a_jour_donnees_client"
+    - "consultation_dossier_medical"
+    - "consultation_contrat_individualise"
+
+permissions:
+  read:
+    - resource: "base_connaissance_publique"
+      max_volume_per_day: 1000
+      fields_allowed:
+        - "articles_faq"
+        - "documents_publics"
+      # Aucune lecture de donnees adherent nominatives.
+  write:
+    - resource: "reponse_client"
+      max_volume_per_day: 800
+      max_tokens_per_response: 600
+  invoke:
+    - action: "creer_ticket_escalade_niveau_2"
+      max_per_day: 500
+    # Aucune action financiere autorisee.
+
+restrictions:
+  forbidden_actions:
+    - "promettre_delai_hors_cgv"
+    - "promettre_remboursement_hors_plafond"
+    - "emettre_avoir"
+    - "emettre_remboursement"
+    - "resilier_contrat"
+    - "modifier_donnees_bancaires"
+    - "acceder_donnees_sante_article_9"
+    - "acceder_donnees_financieres_individuelles"
+    - "transferer_donnees_hors_UE"
+    - "entrainer_modele_tiers_sur_conversations"
+    - "usurper_identite_conseiller_humain"
+
+human_oversight:
+  regime: "human_in_the_loop"
+  # "in_the_loop" : chaque reponse sortante est verifiee avant envoi
+  # pendant la phase de pilote (3 mois). Ensuite bascule possible
+  # vers "on_the_loop" sur decision du comite de conformite.
+  ai_act_reference: "Article 14 + Article 50"
+  pilot_mode_duration_months: 3
+  mandatory_escalation_triggers:
+    - trigger: "toute_demande_contractuelle"
+      threshold: "immediate"
+    - trigger: "toute_demande_financiere"
+      threshold: "immediate"
+    - trigger: "client_manifeste_detresse"
+      threshold: "mot_cle_detecte_ou_sentiment_critique"
+    - trigger: "demande_exercice_droits_rgpd"
+      threshold: "toute_demande"
+  reviewer_profile:
+    role: "conseiller_senior_habilite"
+    training_required: true
+
+expiration:
+  valid_from: "2026-05-01"
+  # Duree courte — le profil restrictif est souvent un pilote.
+  valid_until: "2026-10-31"
+  max_duration_months: 6
+  revocation:
+    immediate_triggers:
+      - "premier_incident_public"
+      - "mise_a_jour_majeure_du_modele_llm"
+
+audit_trail:
+  logged_events:
+    - "ouverture_conversation"
+    - "disclosure_ai_act_article_50_affichee"
+    - "generation_reponse"
+    - "revue_humaine_avant_envoi"
+    - "escalade_humaine"
+    - "cloture_ticket"
+  log_retention_days: 1825
+  # Retention allongee a 5 ans en secteur assurance — a confirmer
+  # selon les recommandations de l'ACPR et de la CNIL applicables.
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "limited_risk_transparency_obligation"
+    annex: "non_applicable_annex_III"
+  gdpr:
+    dpia_required: false
+    dpia_justification: "Pas de donnees article 9 traitees, pas de decision automatisee produisant des effets juridiques. A reevaluer si evolution du perimetre."

--- a/templates/agent-support-client/examples/03-equilibre.yaml
+++ b/templates/agent-support-client/examples/03-equilibre.yaml
@@ -1,0 +1,144 @@
+# Exemple 03 — Mandat EQUILIBRE
+# Profil cible : ETI deja equipee d'un outil de ticketing, volumes
+# moyens, premier deploiement "en vraie grandeur" apres un pilote.
+#
+# Cet exemple reprend les valeurs du gabarit de base. C'est le profil
+# de depart recommande pour la plupart des deploiements.
+
+metadata:
+  template_id: "amr-tpl-support-client-v1"
+  profile: "equilibre"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-21"
+
+principal:
+  type: "legal_entity"
+  legal_name: "Entreprise Exemple SAS"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "000000000"
+  representative:
+    name: "Responsable Relation Client"
+    role: "RRC"
+    email: "rrc@entreprise.example"
+  legal_basis_gdpr:
+    article: "6(1)(b)"
+    description: "Execution du contrat client"
+
+agent:
+  agent_id: "entreprise-support-bot-01"
+  display_name: "Assistant-Support-France"
+  provider: "editeur tiers"
+  model:
+    family: "Claude"
+    version: "Sonnet 4.6"
+    hosted_in: "EU-West"
+  purpose: "Support niveau 1, gestes commerciaux bornes, escalade systematique au-dela des seuils."
+  user_disclosure:
+    ai_act_article_50: true
+    disclosure_text_fr: "Vous echangez avec un assistant virtuel. Un conseiller humain peut prendre le relais a votre demande ou au-dela de certains seuils."
+    disclosure_channels:
+      - "chat_web"
+      - "email_automatique"
+
+scope:
+  business_processes:
+    - "reponse_questions_faq"
+    - "qualification_demande_entrante"
+    - "consultation_historique_client"
+    - "mise_a_jour_donnees_non_sensibles"
+    - "geste_commercial_borne"
+    - "escalade_vers_humain"
+  product_perimeter:
+    - "abonnement_standard"
+    - "vente_unitaire"
+  geographic_scope:
+    - "FR"
+  languages_supported:
+    - "fr"
+  excluded_processes:
+    - "resiliation_contractuelle"
+    - "modification_donnees_bancaires"
+    - "reclamation_contentieuse"
+
+permissions:
+  read:
+    - resource: "historique_client"
+      max_volume_per_day: 2000
+  write:
+    - resource: "reponse_client"
+      max_volume_per_day: 1500
+      max_tokens_per_response: 1200
+    - resource: "mise_a_jour_donnees_non_sensibles"
+      fields_allowed:
+        - "adresse_livraison"
+        - "telephone_secondaire"
+        - "preferences_communication"
+      max_volume_per_day: 200
+      requires_authentication: true
+  invoke:
+    - action: "emettre_avoir"
+      max_amount_eur: 30
+      max_per_customer_per_year: 2
+      max_per_day_global: 50
+      requires_human_approval_above_threshold: true
+    - action: "emettre_remboursement"
+      max_amount_eur: 30
+      max_per_customer_per_year: 2
+      max_per_day_global: 30
+      requires_human_approval_above_threshold: true
+
+restrictions:
+  forbidden_actions:
+    - "promettre_delai_hors_cgv"
+    - "promettre_remboursement_hors_plafond"
+    - "resilier_contrat"
+    - "modifier_donnees_bancaires"
+    - "transferer_donnees_hors_UE"
+    - "usurper_identite_conseiller_humain"
+
+human_oversight:
+  regime: "human_on_the_loop"
+  ai_act_reference: "Article 14 + Article 50"
+  mandatory_escalation_triggers:
+    - trigger: "demande_remboursement_au_dessus_plafond"
+      threshold: 30
+      unit: "euros"
+    - trigger: "client_manifeste_detresse"
+      threshold: "mot_cle_detecte_ou_sentiment_critique"
+    - trigger: "demande_exercice_droits_rgpd"
+      threshold: "toute_demande"
+    - trigger: "conversation_depasse_echanges"
+      threshold: 8
+      unit: "tours_sans_resolution"
+  sampling_review:
+    frequency: "quotidien"
+    sample_size_percent: 2
+    reviewer_role: "superviseur_niveau_2"
+
+expiration:
+  valid_from: "2026-05-01"
+  valid_until: "2027-04-30"
+  max_duration_months: 12
+
+audit_trail:
+  logged_events:
+    - "ouverture_conversation"
+    - "disclosure_ai_act_article_50_affichee"
+    - "lecture_historique_client"
+    - "generation_reponse"
+    - "geste_commercial_emis"
+    - "escalade_humaine"
+    - "cloture_ticket"
+  log_retention_days: 1095
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "limited_risk_transparency_obligation"
+    annex: "non_applicable_annex_III"
+  gdpr:
+    dpia_required: false
+    dpia_justification: "A reevaluer si le perimetre evolue vers des decisions produisant des effets juridiques."

--- a/templates/agent-support-client/mandate.yaml
+++ b/templates/agent-support-client/mandate.yaml
@@ -1,0 +1,249 @@
+# AMR Mandate Template — Agent Support Client
+# Version 1.0 — langue: fr — juridiction: FR-EU
+# Ce fichier est un gabarit. Les valeurs entre < > doivent etre renseignees
+# par l'organisation qui emet le mandat avant chargement dans le registre AMR.
+
+metadata:
+  template_id: "amr-tpl-support-client-v1"
+  template_version: "1.0.0"
+  domain: "relation-client"
+  subdomain: "support-niveau-1"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-21"
+  reference_standards:
+    - "Regulation (EU) 2024/1689 — AI Act (article 50 — transparence)"
+    - "Regulation (EU) 2016/679 — GDPR"
+    - "Code de la consommation (France) — articles L.121-1 et suivants"
+    - "Code civil (France) — article 1103 — force obligatoire du contrat"
+
+principal:
+  type: "legal_entity"
+  legal_name: "<Raison sociale du mandant>"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "<SIREN 9 chiffres>"
+  representative:
+    name: "<Nom du representant habilite>"
+    role: "<Fonction — ex: Directeur Relation Client, DPO>"
+    email: "<email@entreprise.fr>"
+  legal_basis_gdpr:
+    article: "6(1)(b)"
+    description: "Execution du contrat avec le client — traitement de sa demande"
+    alternative_basis:
+      article: "6(1)(f)"
+      description: "Interet legitime — amelioration du service — requiert test de mise en balance"
+
+agent:
+  agent_id: "<identifiant unique interne de l'agent>"
+  display_name: "<nom fonctionnel — ex: Assistant-Support-Marque>"
+  provider: "<editeur ou equipe interne>"
+  model:
+    family: "<famille — ex: Claude, GPT, Mistral>"
+    version: "<version specifique deployee>"
+    hosted_in: "<zone d'hebergement — ex: EU-West>"
+  purpose: "Traiter en premier niveau les demandes entrantes des clients, informer, escalader et executer des gestes commerciaux bornes, sans engagement hors plafond."
+  user_disclosure:
+    ai_act_article_50: true
+    disclosure_text_fr: "Vous echangez avec un assistant virtuel. Un conseiller humain peut prendre le relais a votre demande."
+    disclosure_channels:
+      - "chat_web"
+      - "email_automatique"
+      - "messagerie_instantanee"
+
+scope:
+  business_processes:
+    - "reponse_questions_faq"
+    - "qualification_demande_entrante"
+    - "consultation_historique_client"
+    - "mise_a_jour_donnees_non_sensibles"
+    - "geste_commercial_borne"
+    - "escalade_vers_humain"
+  product_perimeter:
+    - "<lignes de produit couvertes — ex: abonnement_standard, abonnement_premium>"
+  geographic_scope:
+    - "FR"
+  languages_supported:
+    - "fr"
+  excluded_processes:
+    - "resiliation_contractuelle"
+    - "modification_donnees_bancaires"
+    - "reclamation_contentieuse"
+    - "demande_exercice_droits_rgpd"
+    - "plainte_pour_discrimination"
+    - "signalement_vulnerabilite_mineur"
+
+permissions:
+  read:
+    - resource: "historique_client"
+      max_volume_per_day: 2000
+      fields_allowed:
+        - "identifiant_client"
+        - "nom"
+        - "prenom"
+        - "adresse_postale"
+        - "historique_commandes"
+        - "statut_abonnement"
+        - "tickets_anterieurs_resume"
+      fields_forbidden:
+        - "numero_carte_bancaire"
+        - "iban_complet"
+        - "mot_de_passe"
+        - "donnees_sante"
+        - "opinions_politiques_religieuses"
+  write:
+    - resource: "notes_internes_ticket"
+      max_volume_per_day: 2000
+    - resource: "reponse_client"
+      max_volume_per_day: 1500
+      max_tokens_per_response: 1200
+    - resource: "mise_a_jour_donnees_non_sensibles"
+      fields_allowed:
+        - "adresse_livraison"
+        - "telephone_secondaire"
+        - "preferences_communication"
+      max_volume_per_day: 200
+      requires_authentication: true
+  invoke:
+    - action: "emettre_avoir"
+      max_amount_eur: 30
+      max_per_customer_per_year: 2
+      max_per_day_global: 50
+      requires_human_approval_above_threshold: true
+    - action: "emettre_remboursement"
+      max_amount_eur: 30
+      max_per_customer_per_year: 2
+      max_per_day_global: 30
+      requires_human_approval_above_threshold: true
+    - action: "creer_ticket_escalade_niveau_2"
+      max_per_day: 500
+
+restrictions:
+  forbidden_actions:
+    - "promettre_delai_hors_cgv"
+    - "promettre_remboursement_hors_plafond"
+    - "resilier_contrat"
+    - "modifier_donnees_bancaires"
+    - "acceder_cartes_bancaires_en_clair"
+    - "transferer_donnees_hors_UE"
+    - "entrainer_modele_tiers_sur_conversations_clients"
+    - "usurper_identite_conseiller_humain"
+  prohibited_behaviours:
+    description: >
+      L'agent ne peut nier son statut d'agent IA si le client pose la question.
+      Le refus de divulgation constitue une pratique commerciale trompeuse
+      (Code de la consommation, article L.121-2) et un manquement a l'article 50
+      du Reglement (UE) 2024/1689.
+    explicit_rules:
+      - "repondre_honnetement_si_question_suis-je_un_humain"
+      - "proposer_escalade_humain_a_la_demande"
+      - "ne_pas_simuler_emotion_forte_pour_dissuader_escalade"
+
+data_access:
+  categories:
+    - label: "donnees_identite_client"
+      sensitivity: "personal"
+      gdpr_basis: "6(1)(b)"
+    - label: "donnees_contractuelles"
+      sensitivity: "personal"
+      gdpr_basis: "6(1)(b)"
+    - label: "contenu_conversation"
+      sensitivity: "personal"
+      gdpr_basis: "6(1)(b)"
+  special_categories_article_9: "non_autorise"
+  retention:
+    active_ticket_days: 90
+    closed_ticket_days: 1095
+    justification: "3 ans — alignement avec la prescription commerciale de droit commun, article 2224 du Code civil. A VALIDER PAR JURISTE selon le secteur."
+  data_minimization: true
+  transfer_outside_eu: false
+
+human_oversight:
+  regime: "human_on_the_loop"
+  ai_act_reference: "Article 14 (principe general) + Article 50 (transparence)"
+  mandatory_escalation_triggers:
+    - trigger: "demande_remboursement_au_dessus_plafond"
+      threshold: 30
+      unit: "euros"
+    - trigger: "client_manifeste_detresse"
+      threshold: "mot_cle_detecte_ou_sentiment_critique"
+    - trigger: "reclamation_ecrite_qualifiee"
+      threshold: "toute_reclamation_formelle"
+    - trigger: "demande_exercice_droits_rgpd"
+      threshold: "toute_demande"
+    - trigger: "conversation_depasse_echanges"
+      threshold: 8
+      unit: "tours_sans_resolution"
+  sampling_review:
+    frequency: "quotidien"
+    sample_size_percent: 2
+    reviewer_role: "superviseur_niveau_2"
+  reviewer_profile:
+    role: "conseiller_niveau_2_habilite"
+    training_required: true
+    training_topics:
+      - "limites_de_l_agent"
+      - "reconnaissance_situation_vulnerable"
+      - "RGPD_droits_personnes"
+      - "code_de_la_consommation_essentiel"
+
+expiration:
+  valid_from: "<AAAA-MM-JJ>"
+  valid_until: "<AAAA-MM-JJ — 12 mois maximum recommande>"
+  max_duration_months: 12
+  revocation:
+    immediate_triggers:
+      - "incident_de_securite_confirme"
+      - "reclamation_collective"
+      - "mise_a_jour_majeure_du_modele_llm"
+      - "changement_de_cgv"
+      - "changement_de_prestataire_hebergement"
+    revocation_contacts:
+      - "<dpo@entreprise.fr>"
+      - "<direction-relation-client@entreprise.fr>"
+
+audit_trail:
+  logged_events:
+    - "ouverture_conversation"
+    - "disclosure_ai_act_article_50_affichee"
+    - "lecture_historique_client"
+    - "generation_reponse"
+    - "geste_commercial_emis"
+    - "escalade_humaine"
+    - "cloture_ticket"
+  log_retention_days: 1095
+  log_retention_justification: "3 ans — alignement prescription commerciale (article 2224 Code civil). A VALIDER PAR JURISTE."
+  log_access:
+    - "dpo"
+    - "direction_relation_client"
+    - "audit_interne"
+    - "autorite_de_controle_sur_requisition"
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "limited_risk_transparency_obligation"
+    annex: "non_applicable_annex_III"
+    articles:
+      - "Article 50 — transparence vis-a-vis des personnes physiques"
+      - "Article 99, paragraphe 4 — sanctions manquement article 50"
+  gdpr:
+    articles:
+      - "Article 6 — base legale (execution du contrat)"
+      - "Article 5(1)(c) — minimisation"
+      - "Article 5(1)(e) — limitation de conservation"
+      - "Article 13 — information des personnes"
+      - "Article 32 — securite du traitement"
+  national_law_fr:
+    - "Code civil, article 1103 — force obligatoire du contrat"
+    - "Code civil, article 2224 — prescription commerciale"
+    - "Code de la consommation, article L.121-1 — pratiques commerciales deloyales"
+    - "Code de la consommation, article L.121-2 — pratiques trompeuses"
+    - "Code de la consommation, article L.221-18 — droit de retractation"
+
+signature:
+  method: "<eIDAS qualifie | avance | interne>"
+  signed_at: "<AAAA-MM-JJ>"
+  signatory: "<nom et fonction>"
+  signature_ref: "<reference de la signature ou hash>"


### PR DESCRIPTION
Template Tier 3 n°2/10 : `templates/agent-support-client/` — mandat complet (README, mandate.yaml, 3 exemples, 3 fiches conformité, deploy_guide) pour un agent de support client niveau 1 avec plafonds financiers bornés (30–50 €), transparence AI Act article 50 et mapping RGPD + Code de la consommation.
Valeur business immédiate : deuxième pack vendable 2–5 k€ sans dev, cas d'usage le plus courant côté prospects (bien plus courant que RH), ouvre le discours avec toute ETI qui a déjà un Zendesk.
À valider humainement : plafonds financiers par défaut (30 € avoir/remboursement — cohérents avec délégations courantes ?), durées de conservation (3 ans alignés article 2224 Code civil), voix Audric dans README (phrases parfois un peu longues).
Effort Audric pour merger : ~5 min de relecture rapide + merge.

## Auto-check

1. **Audric peut-il vendre ceci en l'état ?** Oui. Le pack est autoportant : README commercial, mandate.yaml prêt à charger, 3 variantes, mapping juridique référencé. Il peut être proposé à 2 000–5 000 € dès aujourd'hui à un prospect e-commerce ou services. Seule la personnalisation au SIREN et aux plafonds du client doit être faite avant signature.
2. **Ce qu'un juriste expert corrigerait en premier** : la durée de conservation de 3 ans (article 2224 Code civil) n'est pas un plancher absolu — certains secteurs (assurance, banque, télécoms) imposent 5 à 10 ans au titre de leurs règles sectorielles. Les mentions « À VALIDER PAR JURISTE » sont présentes aux bons endroits mais un juriste strict pourrait exiger un avertissement plus visible dans le README.
3. **30 % à couper sans perte de valeur** : la fiche `sector_specific.md` couvre beaucoup de secteurs en peu de lignes ; le tableau télécoms et le paragraphe secteur public pourraient être externalisés dans des modules sectoriels futurs sans nuire au pack « support client générique ». Garder : article 1103 + L.121-1, services financiers (DORA, ACPR), clients vulnérables.