### PR TITLE
[Ship] Template — Agent Marketing Contenu v1

### DIFF
--- a/templates/agent-marketing-contenu/README.md
+++ b/templates/agent-marketing-contenu/README.md
@@ -1,0 +1,64 @@
+# Template AMR — Agent Marketing & Contenu
+
+Template de mandat prêt à l'emploi pour encadrer un agent IA déployé en production marketing : génération de contenus éditoriaux, posts réseaux sociaux, séquences email, briefs créatifs, optimisation SEO, recyclage d'assets existants.
+
+## Pour qui
+
+- Directions marketing et communication d'ETI et de grands comptes qui industrialisent la production de contenu avec un agent.
+- Agences et éditeurs qui livrent un agent à leurs clients et doivent fournir une gouvernance documentée à côté du runtime.
+- Responsables conformité, DPO et juristes propriété intellectuelle qui doivent cadrer un déploiement déjà en cours sur des outils type HubSpot, Marketo, Salesforce Marketing Cloud, ou des stacks internes.
+
+## Contexte réglementaire
+
+Un agent de production de contenu marketing n'est pas, en règle générale, classé « à haut risque » au sens de l'**Annexe III du Règlement (UE) 2024/1689** (AI Act). Il relève en revanche de plusieurs régimes superposés :
+
+- L'**article 50 du Règlement (UE) 2024/1689** impose, lorsque l'agent interagit directement avec des personnes physiques (chatbot conversationnel, assistant éditorial public), d'informer la personne qu'elle interagit avec une IA. L'article 50 paragraphe 4 impose en outre, pour les contenus dits « hypertruquages » (deepfakes) et les textes publiés à des fins d'information du public, une obligation de marquage.
+- Le **Règlement (UE) 2016/679 (RGPD)** s'applique dès lors que l'agent traite des données personnelles (segmentation, personnalisation, scoring marketing, A/B testing nominatif).
+- Le **Code de la propriété intellectuelle** français encadre la réutilisation d'œuvres protégées dans les sorties de l'agent (articles L.122-4 et L.122-5).
+- Le **Code de la consommation** sanctionne les pratiques commerciales trompeuses (articles L.121-1 à L.121-5).
+- Le **Règlement (UE) 2022/2065 (Digital Services Act)** crée des obligations de transparence sur la publicité en ligne pour les plateformes intermédiaires.
+
+Déployer un agent marketing sans mandat documenté, c'est laisser la machine produire des claims commerciaux, citer des sources, réutiliser des marques tierces et adresser des audiences segmentées sans borne, sans journal opposable et sans point d'arrêt.
+
+## Trois exemples de déploiement concret
+
+1. **Génération de posts réseaux sociaux** : l'agent reçoit un brief court, produit trois variantes pour LinkedIn, Instagram et X, et propose un calendrier. Aucune publication directe : un humain valide chaque sortie avant programmation.
+2. **Optimisation SEO de pages existantes** : l'agent analyse une page, propose une réécriture optimisée pour un mot-clé cible, suggère des balises et un maillage interne. La publication reste manuelle.
+3. **Personnalisation de séquences email** : l'agent adapte un email-mère à 5 segments d'audience (volume autorisé borné), sans accès aux noms ni adresses, à partir de variables anonymisées. Envoi par l'outil de marketing automation après validation.
+
+## Ce que ce template fournit
+
+- `mandate.yaml` : le mandat structuré prêt à charger dans un registre AMR, avec périmètre éditorial, plafonds de publication, restrictions sur la propriété intellectuelle, seuils d'escalade humaine, durée de validité, cartographie RGPD et AI Act.
+- `examples/` : trois variantes (permissive, restrictive, équilibrée) commentées, pour s'adapter à la maturité éditoriale et au niveau de risque de marque.
+- `compliance/` : trois fiches courtes qui cartographient le mandat avec l'AI Act (articles 50, 26), le RGPD (information, profilage, prospection) et les règles sectorielles (propriété intellectuelle, publicité, secteurs régulés).
+- `deploy_guide.md` : checklist de mise en production et points d'attention sur l'intégration avec un outil de marketing automation ou un CMS.
+
+## Pourquoi c'est risqué sans mandat
+
+Un agent marketing sans mandat documenté expose l'organisation à plusieurs risques concrets :
+
+- **Atteinte aux droits de tiers** : la reproduction non autorisée d'une œuvre protégée est sanctionnée jusqu'à **300 000 € et 3 ans d'emprisonnement** (Code de la propriété intellectuelle, article L.335-2).
+- **Pratiques commerciales trompeuses** : un claim faux sur les caractéristiques d'un produit est sanctionné jusqu'à **300 000 €** pour une personne physique, **1,5 M€** pour une personne morale, et la peine peut être portée à **10 % du chiffre d'affaires moyen annuel** (Code de la consommation, article L.132-2).
+- **Sanctions RGPD** : jusqu'à **20 M€ ou 4 % du chiffre d'affaires mondial** en cas de profilage illicite ou de prospection sans base légale (articles 6, 21, 22, 83).
+- **Sanctions AI Act article 50** : jusqu'à **15 M€ ou 3 % du chiffre d'affaires mondial** pour défaut d'information sur l'interaction avec une IA ou défaut de marquage des contenus générés (article 99, paragraphe 4).
+- **Risque de marque** : un message hors charte, un visuel généré inapproprié ou une prise de position non autorisée coûte plus cher en réputation qu'en amende.
+
+Le mandat AMR ne supprime pas ces risques — il les **borne** (volumes, plafonds, listes de marques interdites) et les **documente** (journal opposable, traçabilité éditoriale).
+
+## Positionnement tarifaire indicatif
+
+Template vendu en pack clé en main, entre **2 000 € et 5 000 €** selon le niveau d'adaptation :
+
+- **Pack standard (2 000 €)** : les fichiers tels quels, licence d'usage interne, une heure d'accompagnement à la configuration.
+- **Pack adapté (3 500 €)** : personnalisation à la charte éditoriale, à la liste de marques tierces interdites et à l'outil de marketing automation en place.
+- **Pack intégré (5 000 €)** : déploiement dans un runtime AMR Tier 1, connexion à l'outil marketing, première revue de conformité par un juriste partenaire.
+
+Le template seul ne remplace pas le runtime mandate-gated (Tier 1 AMR, 350 €/mois) ni une validation par un juriste interne. Il pose la structure ; la décision de publier reste humaine au-delà des seuils.
+
+## À valider côté client avant déploiement
+
+- Revue du mandat par la direction marketing, le service juridique et le DPO.
+- Mise à jour de la notice d'information client (RGPD, article 13) si une personnalisation nominative est activée.
+- Intégration de la mention article 50 de l'AI Act sur les canaux conversationnels publics (chatbot, formulaire intelligent).
+- Validation de la liste des marques, personnalités et œuvres exclues du périmètre.
+- Formation des équipes éditoriales aux cas d'escalade et au refus de publication.

--- a/templates/agent-marketing-contenu/compliance/ai_act_mapping.md
+++ b/templates/agent-marketing-contenu/compliance/ai_act_mapping.md
@@ -1,0 +1,62 @@
+# Cartographie AI Act — Agent Marketing & Contenu
+
+Référence : **Règlement (UE) 2024/1689** du Parlement européen et du Conseil établissant des règles harmonisées concernant l'intelligence artificielle.
+
+## Classification
+
+Un agent de production de contenu marketing n'est pas, en règle générale, listé à l'**Annexe III** du Règlement. Il ne décide ni d'un emploi, ni d'un crédit, ni d'un droit social. À ce titre, il ne relève **pas** du régime des systèmes à haut risque du Chapitre III, Section 2.
+
+Il relève en revanche de l'**article 50 du Règlement**, qui impose des obligations de transparence et, pour certains contenus, de marquage.
+
+## Obligation principale — Article 50, paragraphe 1 (interaction)
+
+> Article 50, paragraphe 1 : « Les fournisseurs veillent à ce que les systèmes d'IA destinés à interagir directement avec des personnes physiques soient conçus et développés de manière à ce que les personnes physiques concernées soient informées qu'elles interagissent avec un système d'IA, sauf si cela est évident pour une personne physique raisonnablement bien informée, attentive et avisée. »
+
+Dans le template : section `agent.user_disclosure`, champs `disclosure_text_fr` et `disclosure_channels`. Couvre les cas chatbot site public, formulaire intelligent, assistant éditorial externe.
+
+## Obligation centrale — Article 50, paragraphe 4 (marquage des contenus)
+
+> Article 50, paragraphe 4 : « Les déployeurs d'un système d'IA qui génère ou manipule des images ou des contenus audio ou vidéo constituant un hypertruquage indiquent que les contenus ont été générés ou manipulés par une IA. […] Les déployeurs d'un système d'IA qui génère ou manipule des textes publiés dans le but d'informer le public sur des questions d'intérêt public indiquent que le texte a été généré ou manipulé par une IA. »
+
+Dans le template : section `agent.output_marking` qui exige un marquage machine-readable (C2PA ou équivalent) sur tout contenu généré ou substantiellement modifié, et une mention humaine visible quand le contexte éditorial l'exige.
+
+**Limites de l'obligation textuelle** : l'obligation de mention visible ne s'applique pas systématiquement au contenu purement promotionnel et publicitaire de l'entreprise sur ses propres canaux ; elle vise les contenus « informant le public sur des questions d'intérêt public ». Le gabarit retient une lecture prudente : marquage technique systématique, mention humaine adaptée au contexte. **À VALIDER PAR JURISTE** au cas par cas.
+
+## Obligation du déployeur — Article 26
+
+L'article 26 impose au déployeur d'un système d'IA :
+
+- Utiliser le système conformément à la notice (paragraphe 1).
+- Confier la supervision humaine à des personnes formées (paragraphe 2).
+- Tenir à jour les journaux générés automatiquement, dans la limite du contrôle du déployeur (paragraphe 6).
+
+Dans le template : la responsabilité du déployeur est matérialisée par `principal.representative`, `human_oversight.reviewer_profile`, `audit_trail`.
+
+## Obligation complémentaire — Article 14 (principe général)
+
+Bien que non formellement obligatoire hors haut risque, le principe de supervision humaine de l'article 14 est transposé par la règle `human_oversight.mandatory_validation_before_publication: true`. Aucun contenu ne quitte l'environnement de l'agent sans décision humaine de publication.
+
+## Calendrier d'application
+
+Les obligations de l'article 50 s'appliquent à partir du **2 août 2026**, conformément à l'article 113 du Règlement. Cette date n'est pas concernée, à ce stade, par les discussions de report en cours sur le paquet dit « Digital Omnibus », qui portent principalement sur les systèmes à haut risque de l'Annexe III. **À suivre au regard des trilogues.**
+
+## Sanctions encourues
+
+Article 99, paragraphe 4 : jusqu'à **15 M€ ou 3 % du chiffre d'affaires mondial annuel**, le montant le plus élevé étant retenu, pour les manquements aux obligations applicables aux fournisseurs ou aux déployeurs, y compris l'article 50.
+
+## Rôle du déployeur vs fournisseur
+
+L'article 50 impose des obligations à la fois au **fournisseur** du système (celui qui conçoit le modèle et le met sur le marché) et au **déployeur** (l'entreprise qui exploite l'agent). Pour le marquage des contenus (article 50, paragraphe 4), l'obligation pèse expressément sur le **déployeur**.
+
+Le déployeur reste également responsable au titre de l'article 26 :
+- s'assurer que la notice de transparence est affichée sur les canaux conversationnels publics ;
+- s'assurer que le marquage des contenus est correctement appliqué dans la chaîne de publication ;
+- former les équipes humaines aux cas d'escalade ;
+- tenir à jour les journaux de fonctionnement.
+
+## Points à valider par un juriste
+
+- Confirmer l'absence de bascule en Annexe III pour les cas d'usage périphériques. Exemple : si l'agent participe à du *lead scoring* qui décide d'une éligibilité commerciale produisant un effet juridique, l'article 22 du RGPD et possiblement l'Annexe III peuvent être déclenchés. **À VALIDER PAR JURISTE.**
+- Confirmer l'étendue exacte de l'obligation de mention visible de l'article 50, paragraphe 4 selon la nature du contenu (publicitaire, éditorial, journalistique, intérêt public).
+- Vérifier l'articulation avec le **Règlement (UE) 2022/2065 (DSA)** si l'organisation est qualifiée de plateforme intermédiaire ou si elle place des annonces ciblées.
+- Vérifier l'articulation avec les recommandations du **Conseil supérieur de l'audiovisuel et du numérique (Arcom)** si du contenu audiovisuel est généré.

--- a/templates/agent-marketing-contenu/compliance/rgpd_mapping.md
+++ b/templates/agent-marketing-contenu/compliance/rgpd_mapping.md
@@ -1,0 +1,75 @@
+# Cartographie RGPD — Agent Marketing & Contenu
+
+Référence : **Règlement (UE) 2016/679** du Parlement européen et du Conseil relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel (RGPD).
+
+## Base légale du traitement
+
+Deux bases légales coexistent dans le périmètre marketing, et le mandat doit choisir explicitement l'une ou l'autre selon le canal et le pays de la personne :
+
+- **Article 6, paragraphe 1, point f)** — intérêt légitime. Base par défaut pour la prospection de clients existants en B2B et pour la personnalisation de contenu sur les canaux propres (site web, espace client). Requiert un **test de mise en balance** documenté entre l'intérêt du responsable de traitement et les droits et libertés des personnes concernées (considérant 47 RGPD, lignes directrices CEPD 2024 sur l'intérêt légitime).
+- **Article 6, paragraphe 1, point a)** — consentement. Base obligatoire pour la prospection électronique B2C en France (article L.34-5 du Code des postes et communications électroniques) et pour le suivi de comportement sur les sites web (cookies non strictement nécessaires, articles 82 de la loi Informatique et Libertés et lignes directrices CNIL).
+
+Le gabarit retient l'intérêt légitime par défaut et documente une base alternative consentement. **Choix à valider par le DPO.**
+
+## Information des personnes — Articles 12 à 14
+
+L'article 13 du RGPD impose d'informer la personne au moment de la collecte. Pour un agent marketing, deux niveaux d'information se superposent :
+
+1. **Notice RGPD complète** : politique de confidentialité du site, finalités marketing détaillées (segmentation, personnalisation, prospection), durée de conservation, droits, contact DPO. Responsabilité du déployeur, hors du mandat.
+2. **Notice courte « agent IA »** : affichée en ouverture d'interaction conversationnelle au titre de l'article 50, paragraphe 1 du Règlement (UE) 2024/1689. Pour le contenu non-conversationnel (post social, article), le marquage de l'article 50, paragraphe 4 prend le relais.
+
+Dans le template : section `agent.user_disclosure` pour le conversationnel, `agent.output_marking` pour le contenu publié.
+
+## Profilage et droit d'opposition — Articles 4(4), 21 et 22
+
+Si l'agent contribue à segmenter automatiquement une audience pour adresser des contenus différenciés, il participe à un **profilage** au sens de l'article 4, paragraphe 4 du RGPD. L'article 21, paragraphe 2 confère à la personne un droit d'opposition à tout moment au traitement à des fins de prospection, **y compris au profilage lié à cette prospection**. Ce droit ne peut pas être restreint par un intérêt légitime.
+
+Dans le template : `data_access.categories` distingue les données agrégées anonymisées (segment_id, centre d'intérêt) des données nominatives (interdites en lecture pour l'agent). Le mandat doit s'articuler avec un mécanisme externe d'opt-out, généralement géré par l'outil de marketing automation.
+
+L'article 22 du RGPD interdit, sauf exceptions, toute décision fondée exclusivement sur un traitement automatisé produisant des effets juridiques ou affectant significativement la personne. Un agent qui adresserait automatiquement une offre commerciale différenciée n'entre généralement pas dans le champ de l'article 22 (l'effet n'est pas significatif au sens du considérant 71). En revanche, un agent qui exclurait automatiquement une personne d'une offre, ou qui modulerait un prix de façon décisive, peut entrer dans ce champ. **À VALIDER PAR DPO.**
+
+## Minimisation — Article 5, paragraphe 1, point c)
+
+Le mandat liste explicitement les champs autorisés en lecture (`permissions.read.fields_allowed`) et les champs interdits (`fields_forbidden`). L'agent travaille par défaut sur des données d'audience **agrégées et anonymisées** (segment_id, centre d'intérêt, comportement agrégé). Les noms, adresses email, téléphones et identifiants individuels réconciliables sont exclus. La personnalisation nominative, si elle est activée, doit être traitée hors agent par l'outil d'envoi.
+
+## Limitation de conservation — Article 5, paragraphe 1, point e)
+
+Trois durées sont distinguées :
+
+- **Brouillons et variantes générés** : 365 jours, pour traçabilité éditoriale et reconstitution du raisonnement de l'agent en cas de contestation d'un tiers.
+- **Contenus publiés** : durée de vie commerciale du produit ou du service auquel ils se rapportent.
+- **Données d'audience consultées** : alignement avec la politique générale du responsable de traitement (référentiel CNIL sur la prospection commerciale : trois ans à compter du dernier contact pour les prospects).
+
+**À VALIDER PAR DPO** au regard du référentiel CNIL applicable au secteur.
+
+## Sécurité du traitement — Article 32
+
+Le template prévoit :
+
+- Chaîne SHA-256 sur les journaux (`audit_trail.tamper_evidence: sha256_chain`) pour garantir l'intégrité.
+- Accès aux journaux restreint à cinq rôles nominatifs.
+- Interdiction de transfert hors UE (`restrictions.forbidden_actions`).
+- Interdiction de réutilisation des contenus de marque pour entraîner un modèle tiers (`data_access.training_on_proprietary_data.allowed: false`).
+
+## Analyse d'impact — Article 35
+
+**DPIA non systématiquement obligatoire** pour le périmètre du gabarit (production de contenu). Elle devient obligatoire en cas de :
+
+- Profilage à grande échelle utilisé pour évaluer ou prendre des décisions concernant les personnes (liste CNIL des traitements soumis à DPIA, point 1).
+- Traitement à grande échelle de données sensibles (article 9).
+- Croisement de jeux de données provenant de sources distinctes.
+
+**À VALIDER PAR DPO** au regard du périmètre exact du déploiement.
+
+## Articulation avec les directives ePrivacy et la loi Informatique et Libertés
+
+- **Directive 2002/58/CE (ePrivacy)** transposée à l'**article 82 de la loi n° 78-17 du 6 janvier 1978 (Informatique et Libertés)** : le suivi sur terminal nécessite un consentement préalable. L'agent ne déclenche pas lui-même ces traceurs, mais ses sorties peuvent être servies sur des pages soumises à ce régime.
+- **Article L.34-5 du Code des postes et communications électroniques** : prospection électronique vers une personne physique (B2C) interdite sans consentement préalable, sauf produits ou services analogues à ceux déjà fournis.
+
+## Points à valider par un juriste ou un DPO
+
+- Choisir entre intérêt légitime et consentement selon le canal et le pays.
+- Documenter le test de mise en balance si l'intérêt légitime est retenu.
+- Vérifier que l'agent ne bascule pas sous l'article 22 par effet de bord (segmentation décisive).
+- Valider la durée de conservation des brouillons au regard du référentiel sectoriel.
+- Vérifier la conformité du marquage des contenus avec l'article 50, paragraphe 4 de l'AI Act.

--- a/templates/agent-marketing-contenu/compliance/sector_specific.md
+++ b/templates/agent-marketing-contenu/compliance/sector_specific.md
@@ -1,0 +1,86 @@
+# Règles sectorielles — Agent Marketing & Contenu
+
+Ce document liste les règles additionnelles à vérifier selon le secteur d'activité du déployeur et la nature du contenu produit. Le gabarit de mandat est secteur-neutre ; il doit être complété par les obligations sectorielles applicables.
+
+## Principe transversal — Propriété intellectuelle
+
+- **Article L.122-4 du Code de la propriété intellectuelle** : « Toute représentation ou reproduction intégrale ou partielle faite sans le consentement de l'auteur […] est illicite. » L'agent ne peut reproduire ni transformer une œuvre protégée sans licence.
+- **Article L.122-5 du Code de la propriété intellectuelle** : exceptions, dont la **citation brève** au paragraphe 3, point a) — sous condition de mention de la source et du nom de l'auteur, finalité critique, polémique, pédagogique, scientifique ou d'information, et caractère bref proportionné à la finalité.
+- **Article L.335-2 du Code de la propriété intellectuelle** : la contrefaçon est punie de **3 ans d'emprisonnement et 300 000 € d'amende**, portée à 7 ans et 750 000 € en bande organisée.
+- **Article L.713-2 du Code de la propriété intellectuelle** : interdiction de l'usage non autorisé d'une marque enregistrée pour des produits ou services identiques ou similaires.
+
+Dans le mandat : `restrictions.forbidden_actions` exclut explicitement la reproduction d'œuvre protégée et la citation de marque tierce sans autorisation documentée.
+
+## Principe transversal — Pratiques commerciales
+
+- **Article L.121-1 du Code de la consommation** : interdiction des pratiques commerciales déloyales, dont les pratiques trompeuses (article L.121-2) et agressives (article L.121-6).
+- **Article L.132-2 du Code de la consommation** : sanctions des pratiques trompeuses jusqu'à **300 000 €** pour une personne physique, **1,5 M€** pour une personne morale, montant pouvant être porté à **10 % du chiffre d'affaires moyen annuel calculé sur les trois derniers exercices**.
+- **Article L.121-4 du Code de la consommation** : liste noire des pratiques réputées trompeuses en toutes circonstances. Inclut notamment toute affirmation inexacte sur les caractéristiques essentielles d'un produit ou d'un service.
+
+Dans le mandat : `restrictions.forbidden_actions` exclut les claims chiffrés non sourcés et les promesses de résultat non garanti.
+
+## Principe transversal — Concurrence
+
+- **Article L.122-1 du Code de la consommation** : la publicité comparative est licite sous conditions strictes (objectivité, vérifiabilité, non-dénigrement). Le gabarit interdit par défaut la comparaison nominative avec un concurrent (`scope.excluded_processes`).
+
+## Plateformes en ligne et publicité ciblée
+
+- **Règlement (UE) 2022/2065 (Digital Services Act)** :
+  - **Article 26** : transparence de la publicité en ligne — l'utilisateur doit pouvoir identifier qu'il s'agit d'une publicité, qui en est à l'origine, et sur quels paramètres principaux il a été ciblé.
+  - **Article 28** : protection renforcée des mineurs, interdiction du ciblage publicitaire fondé sur le profilage des mineurs.
+  - **Article 39** : registre public des publicités pour les très grandes plateformes en ligne.
+- Si l'organisation est une plateforme intermédiaire, ces obligations s'ajoutent au mandat. Sinon, elles concernent l'écosystème dans lequel les contenus sont diffusés et doivent être anticipées.
+
+## E-commerce et vente à distance
+
+- **Article L.111-1 du Code de la consommation** : obligation précontractuelle d'information sur les caractéristiques essentielles, le prix et la durée du contrat. Une fiche produit générée par l'agent doit respecter cette obligation au pixel près.
+- **Article L.221-5 du Code de la consommation** : information préalable obligatoire dans le cadre des contrats à distance. **À VALIDER PAR JURISTE** si l'agent rédige des fiches produits transactionnelles.
+
+## Services financiers et assurance
+
+- **Code monétaire et financier, article L.533-12** : obligation de communication claire, exacte et non trompeuse. La publicité sur un service d'investissement est soumise au visa ou à la déclaration ACPR/AMF selon les cas.
+- **Code monétaire et financier, article L.341-3** : règles strictes de démarchage bancaire et financier.
+- **Code des assurances, article L.521-1** : devoir d'information et de conseil de l'intermédiaire d'assurance.
+- **Recommandation ACPR 2023-R-01** relative à la gouvernance des algorithmes : à intégrer dans le mandat sous forme de points de contrôle humains.
+- **Profil restrictif** (`examples/02-restrictif.yaml`) recommandé pour ce secteur en première intention.
+
+## Santé, dispositifs médicaux et médicaments
+
+- **Code de la santé publique, article L.5122-1 et suivants** : la publicité pour les médicaments est strictement encadrée, contrôle préalable de l'ANSM pour le grand public.
+- **Code de la santé publique, article L.5213-1 et suivants** : règles spécifiques pour la publicité des dispositifs médicaux.
+- **Décret n° 2017-1417 du 28 septembre 2017** : encadrement de la communication des établissements de santé.
+- **Article L.4113-9 du Code de la santé publique** : interdiction de toute publicité directe ou indirecte par les professionnels de santé hors mentions autorisées.
+- L'agent doit exclure tout contenu de promotion santé directe et passer par le template santé dédié pour ce secteur.
+
+## Tabac, alcool, jeux d'argent
+
+- **Loi n° 91-32 du 10 janvier 1991 (loi Évin)** : interdiction de toute publicité indirecte pour le tabac ; règles strictes pour l'alcool (mentions obligatoires, supports limitatifs).
+- **Code de la santé publique, article L.3323-2** : limitation des supports autorisés pour la publicité d'alcool.
+- **Code de la sécurité intérieure, article L.320-12** : encadrement strict de la publicité des opérateurs de jeux.
+- L'agent doit exclure ces secteurs sauf paramétrage explicite et validation juridique.
+
+## Immobilier
+
+- **Loi n° 70-9 du 2 janvier 1970 (loi Hoguet)** et son décret d'application : règles d'affichage des annonces immobilières (prix, honoraires, surface loi Carrez).
+- **Arrêté du 10 janvier 2017** sur l'information précontractuelle relative aux honoraires.
+- **À VALIDER PAR JURISTE** si l'agent rédige des annonces immobilières — risque de DGCCRF élevé.
+
+## Secteur public et marchés publics
+
+- **Code des relations entre le public et l'administration, article L.311-3-1** : obligation d'information sur l'usage d'un traitement algorithmique fondant une décision individuelle. À combiner avec l'article 50 de l'AI Act.
+- Communication institutionnelle d'État ou de collectivité : règles d'affichage de la marque État ou des collectivités (charte communication gouvernementale).
+
+## Mineurs et publics vulnérables
+
+- **Code de la consommation, article L.121-21** : protection renforcée des consommateurs vulnérables.
+- **Article 28 du DSA** : interdiction du ciblage publicitaire des mineurs sur les plateformes intermédiaires.
+- **Recommandations ARPP** : encadrement déontologique de la communication à destination des enfants.
+
+Le mandat exclut par défaut la production de contenu à destination des mineurs sans supervision (`restrictions.forbidden_actions`).
+
+## Points à valider par un juriste
+
+- Confirmer le rattachement sectoriel et lister les régulateurs sectoriels concernés (DGCCRF, ARPP, ACPR, AMF, ANSM, Arcom, CNIL).
+- Établir et tenir à jour la **liste blanche des marques tierces** dont la mention est autorisée (presse, partenariats, citations clients avec accord écrit).
+- Vérifier les chartes éditoriales et de marque internes ; les annexer au mandat.
+- Auditer l'outil de marketing automation et le CMS pour la traçabilité des publications validées par l'humain.

--- a/templates/agent-marketing-contenu/deploy_guide.md
+++ b/templates/agent-marketing-contenu/deploy_guide.md
@@ -1,0 +1,80 @@
+# Guide de déploiement — Agent Marketing & Contenu
+
+Ce guide accompagne la mise en production du mandat AMR pour un agent de production de contenu marketing. Il s'adresse à l'équipe qui opère le déploiement (marketing, juridique, IT, DPO).
+
+## Avant de commencer — checklist de pré-requis
+
+- [ ] Charte éditoriale et guide de marque à jour, accessibles à l'agent en lecture seule.
+- [ ] Liste blanche des marques tierces autorisées (clients, partenaires, citations presse) validée par le juridique.
+- [ ] Politique de confidentialité du site web mise à jour pour mentionner l'usage d'un agent IA dans le marketing (article 13 RGPD).
+- [ ] DPO identifié et associé au projet, avec accord écrit sur le mandat.
+- [ ] Responsable éditorial désigné et formé aux cas d'escalade.
+- [ ] Outil de marketing automation et CMS audités : capacité à recevoir des brouillons, à tracer la décision humaine de publication, à conserver les journaux.
+
+## Étape 1 — Renseigner les valeurs du gabarit
+
+Ouvrir `mandate.yaml` et remplacer toutes les valeurs entre `< >` par les valeurs propres à l'organisation : raison sociale, SIREN, identité du représentant, identifiants de l'agent, version du modèle LLM, zone d'hébergement, dates de validité.
+
+Pour les volumes (`max_volume_per_day`, `max_per_day`), partir des valeurs du profil équilibré (`examples/03-equilibre.yaml`) et ajuster à la baisse pour un premier déploiement. Il est plus simple d'augmenter un plafond après quelques semaines de retour terrain que de l'abaisser après un incident.
+
+## Étape 2 — Choisir le profil
+
+Sélectionner un des trois exemples :
+
+- `examples/01-permissif.yaml` : équipe éditoriale mature, charte stricte, redacteur en chef dédié.
+- `examples/02-restrictif.yaml` : secteur régulé (banque, assurance, santé) ou phase pilote.
+- `examples/03-equilibre.yaml` : profil par défaut recommandé pour la majorité des ETI B2B.
+
+Copier le contenu du profil choisi par-dessus les sections correspondantes de `mandate.yaml`. Conserver les sections `metadata`, `compliance_mapping` et `audit_trail` du gabarit principal.
+
+## Étape 3 — Validation juridique
+
+Soumettre le mandat complet :
+
+1. Au **DPO** : valider la base légale RGPD, la durée de conservation, l'absence de bascule article 22.
+2. Au **service juridique** : valider les exclusions propriété intellectuelle, la liste des marques autorisées, les claims réglementés selon le secteur.
+3. Au **directeur marketing** : valider l'alignement avec la charte éditoriale et les volumes attendus.
+
+Toute zone marquée **À VALIDER PAR JURISTE** dans les fichiers `compliance/` doit faire l'objet d'une décision documentée avant mise en production.
+
+## Étape 4 — Intégration technique
+
+- Charger `mandate.yaml` dans le registre AMR (Tier 1 ou auto-hébergé).
+- Configurer l'agent pour qu'il appelle le registre AMR avant chaque action mentionnée dans `permissions.invoke`. Sans token mandate-gated, l'agent ne doit pas pouvoir soumettre, publier ni envoyer.
+- Activer le marquage C2PA (ou équivalent) dans la chaîne de génération, conformément à `agent.output_marking`.
+- Activer les journaux SHA-256 chaînés (`audit_trail.tamper_evidence`).
+- Brancher le CMS et l'outil de marketing automation pour qu'aucune publication ne soit possible sans validation humaine traçable.
+
+## Étape 5 — Formation
+
+- Former le ou les **réviseurs** désignés (responsable éditorial, redacteur en chef) aux cinq sujets listés dans `human_oversight.reviewer_profile.training_topics` : limites de l'agent, droit d'auteur et droit des marques, RGPD prospection et profilage, AI Act articles 50 et 26, code de la consommation pratiques commerciales.
+- Préparer un **kit d'incident** : qui contacter, comment révoquer le mandat, comment retirer un contenu publié à tort.
+
+## Étape 6 — Mise en production progressive
+
+Recommandation : trois phases.
+
+1. **Pilote silencieux (2-4 semaines)** : l'agent produit, l'humain valide, mais aucune publication n'est faite à partir des sorties de l'agent. Objectif : mesurer la qualité, ajuster les seuils.
+2. **Pilote ouvert (4-8 semaines)** : publication avec mention humaine visible systématique, échantillonnage 100 % par le réviseur. Objectif : valider l'alignement avec la charte.
+3. **Production (sans limite, durée du mandat)** : passage à l'échantillonnage statistique, conformément au profil retenu. Suivi mensuel des indicateurs.
+
+## Points d'attention critiques
+
+- **Aucune publication directe** : même en profil permissif, le mandat impose `max_per_day: 0` pour `publier_post_social` et `envoyer_campagne_email`. Cette règle ne doit jamais être contournée.
+- **Marquage** : l'article 50, paragraphe 4 de l'AI Act est applicable au **2 août 2026**. La chaîne de marquage doit être opérationnelle à cette date pour éviter le risque d'amende article 99, paragraphe 4.
+- **Marques tierces** : la mention d'une marque concurrente, même bienveillante, sans autorisation écrite, expose à l'article L.713-2 du Code de la propriété intellectuelle. La liste blanche est le seul périmètre autorisé.
+- **Données d'audience** : l'agent ne lit jamais de données nominatives. La personnalisation nominative est faite hors agent par l'outil d'envoi.
+
+## Checklist finale avant mise en prod
+
+- [ ] `mandate.yaml` validé par DPO, juridique, marketing.
+- [ ] Profil choisi et appliqué.
+- [ ] Liste blanche des marques tierces annexée.
+- [ ] Charte éditoriale annexée.
+- [ ] Marquage C2PA fonctionnel.
+- [ ] Journaux SHA-256 chaînés actifs.
+- [ ] Aucune action de publication ne peut s'exécuter sans token AMR valide.
+- [ ] Réviseur formé.
+- [ ] Procédure de révocation documentée et testée.
+- [ ] Notice utilisateur (article 50.1) en place sur les canaux conversationnels publics.
+- [ ] Politique de confidentialité mise à jour.

--- a/templates/agent-marketing-contenu/examples/01-permissif.yaml
+++ b/templates/agent-marketing-contenu/examples/01-permissif.yaml
@@ -1,0 +1,75 @@
+# Exemple PERMISSIF — Agent Marketing & Contenu
+# Profil: equipe editoriale mature, charte stricte deja en place,
+# responsable editorial dedie a la revue. Volumes eleves, soumission
+# directe au CMS comme brouillon (jamais publication directe).
+# A reserver aux organisations ayant un niveau de maturite eleve.
+
+metadata:
+  template_id: "amr-tpl-marketing-contenu-v1"
+  profile: "permissif"
+  language: "fr"
+  jurisdiction: "FR-EU"
+
+principal:
+  legal_name: "Acme Media SA"
+  representative:
+    role: "Directrice Editoriale"
+
+agent:
+  display_name: "Editorial-Assistant-Pro"
+  purpose: "Production a haut volume de brouillons editoriaux pour validation par redacteurs en chef."
+  output_marking:
+    ai_act_article_50_paragraph_4: true
+    marking_rule: "Marquage C2PA systematique sur tout brouillon. Mention humaine visible ajoutee a la publication par le redacteur en chef."
+
+scope:
+  business_processes:
+    - "generation_post_reseaux_sociaux"
+    - "redaction_article_blog"
+    - "redaction_email_marketing"
+    - "optimisation_seo_page_existante"
+    - "brief_creatif_pour_designer"
+    - "recyclage_asset_existant"
+    - "traduction_contenu_existant"
+  channels_authorized:
+    - "linkedin"
+    - "instagram"
+    - "x_twitter"
+    - "blog_corporate"
+    - "newsletter_opt_in"
+    - "site_web_public"
+
+permissions:
+  write:
+    # Volume eleve, mais aucune publication directe.
+    - resource: "brouillon_contenu_a_valider"
+      max_volume_per_day: 500
+      max_tokens_per_output: 4000
+    - resource: "variante_post_social"
+      max_volume_per_day: 300
+      max_tokens_per_output: 600
+  invoke:
+    # CRITIQUE : meme en profil permissif, aucune publication directe.
+    # L'agent ne peut que SOUMETTRE comme brouillon.
+    - action: "publier_post_social"
+      max_per_day: 0
+      requires_human_approval: true
+    - action: "envoyer_campagne_email"
+      max_per_day: 0
+      requires_human_approval: true
+    - action: "soumettre_brouillon_au_cms"
+      max_per_day: 100
+      requires_human_approval: true
+      approval_role: "redacteur_en_chef"
+
+human_oversight:
+  regime: "human_in_the_loop"
+  # Revue par echantillonnage statistique haute frequence,
+  # validation systematique au moment de la publication.
+  sampling_review:
+    frequency: "quotidien"
+    sample_size_percent: 20
+    reviewer_role: "responsable_editorial"
+
+expiration:
+  max_duration_months: 12

--- a/templates/agent-marketing-contenu/examples/02-restrictif.yaml
+++ b/templates/agent-marketing-contenu/examples/02-restrictif.yaml
@@ -1,0 +1,81 @@
+# Exemple RESTRICTIF — Agent Marketing & Contenu
+# Profil: secteur regule (banque, assurance, sante, defense),
+# premier deploiement, faible appetit au risque de marque,
+# sortie a chaque etape revue manuellement avant tout transfert.
+# A reserver pour pilote initial ou contexte sensible.
+
+metadata:
+  template_id: "amr-tpl-marketing-contenu-v1"
+  profile: "restrictif"
+  language: "fr"
+  jurisdiction: "FR-EU"
+
+principal:
+  legal_name: "Banque Exemple SA"
+  representative:
+    role: "Directeur Communication et Conformite"
+  legal_basis_gdpr:
+    article: "6(1)(a)"
+    description: "Consentement obligatoire — secteur banque, prospection electronique B2C requiert opt-in (article L.34-5 CPCE)"
+
+agent:
+  display_name: "Editorial-Assistant-Pilote"
+  purpose: "Production restreinte de brouillons, soumission unique a un comite editorial elargi avant tout usage."
+  output_marking:
+    ai_act_article_50_paragraph_4: true
+    marking_rule: "Marquage C2PA + mention humaine visible obligatoire. Filigrane visible sur tout visuel."
+
+scope:
+  business_processes:
+    # Perimetre volontairement etroit.
+    - "redaction_article_blog"
+    - "optimisation_seo_page_existante"
+    - "traduction_contenu_existant"
+  channels_authorized:
+    - "blog_corporate"
+    - "site_web_public"
+  excluded_processes:
+    # En plus des exclusions du gabarit, on ajoute :
+    - "publication_directe_sans_validation_humaine"
+    - "envoi_email_a_liste_non_opt_in"
+    - "generation_image_personne_identifiable_sans_consentement"
+    - "generation_voix_synthese_personne_identifiable"
+    - "communication_de_crise"
+    - "communication_resultats_financiers_societe_cotee"
+    - "prise_de_position_politique_ou_religieuse"
+    - "comparaison_nominative_avec_concurrent"
+    - "production_post_reseaux_sociaux"
+    - "production_email_marketing"
+    - "claim_chiffre_meme_source_interne"
+    - "evocation_produit_d_investissement"
+    - "evocation_taux_ou_rendement"
+
+permissions:
+  write:
+    - resource: "brouillon_contenu_a_valider"
+      max_volume_per_day: 20
+      max_tokens_per_output: 2000
+  invoke:
+    - action: "soumettre_brouillon_au_cms"
+      max_per_day: 5
+      requires_human_approval: true
+      # Validation a deux niveaux pour secteurs regules.
+      approval_role: "comite_editorial_et_conformite"
+      dual_approval: true
+
+human_oversight:
+  regime: "human_in_the_loop"
+  # 100% des sorties revues, conformement aux recommandations
+  # ACPR 2023-R-01 sur la gouvernance des algorithmes (secteur banque).
+  sampling_review:
+    frequency: "par_sortie"
+    sample_size_percent: 100
+    reviewer_role: "comite_editorial_et_conformite"
+
+expiration:
+  # Duree courte pour reevaluation rapide en phase pilote.
+  max_duration_months: 3
+
+audit_trail:
+  log_retention_days: 1825
+  log_retention_justification: "5 ans — secteur banque, prescription contentieux DGCCRF + ACPR."

--- a/templates/agent-marketing-contenu/examples/03-equilibre.yaml
+++ b/templates/agent-marketing-contenu/examples/03-equilibre.yaml
@@ -1,0 +1,75 @@
+# Exemple EQUILIBRE — Agent Marketing & Contenu
+# Profil: ETI B2B SaaS, equipe marketing structuree mais petite,
+# usage quotidien sur un perimetre defini, validation par
+# echantillonnage statistique en plus de la validation editoriale
+# par defaut. Profil par defaut recommande pour la plupart des deploiements.
+
+metadata:
+  template_id: "amr-tpl-marketing-contenu-v1"
+  profile: "equilibre"
+  language: "fr"
+  jurisdiction: "FR-EU"
+
+principal:
+  legal_name: "Acme Software SAS"
+  representative:
+    role: "Head of Marketing"
+
+agent:
+  display_name: "Editorial-Assistant-Standard"
+  purpose: "Production quotidienne de brouillons editoriaux et variantes pour validation par l'equipe marketing avant publication."
+  output_marking:
+    ai_act_article_50_paragraph_4: true
+    marking_rule: "Marquage C2PA systematique. Mention humaine visible appliquee selon la nature du contenu (article long: oui ; post court reformule: non, mais traçabilite interne)."
+
+scope:
+  business_processes:
+    - "generation_post_reseaux_sociaux"
+    - "redaction_article_blog"
+    - "redaction_email_marketing"
+    - "optimisation_seo_page_existante"
+    - "brief_creatif_pour_designer"
+    - "recyclage_asset_existant"
+  channels_authorized:
+    - "linkedin"
+    - "blog_corporate"
+    - "newsletter_opt_in"
+    - "site_web_public"
+
+permissions:
+  write:
+    - resource: "brouillon_contenu_a_valider"
+      max_volume_per_day: 80
+      max_tokens_per_output: 3000
+    - resource: "variante_post_social"
+      max_volume_per_day: 40
+      max_tokens_per_output: 600
+    - resource: "brief_creatif_interne"
+      max_volume_per_day: 20
+  invoke:
+    # Aucune publication directe. Tous les brouillons partent dans le CMS
+    # en statut "draft" pour validation par un humain.
+    - action: "publier_post_social"
+      max_per_day: 0
+      requires_human_approval: true
+    - action: "envoyer_campagne_email"
+      max_per_day: 0
+      requires_human_approval: true
+    - action: "soumettre_brouillon_au_cms"
+      max_per_day: 30
+      requires_human_approval: true
+      approval_role: "responsable_editorial"
+    - action: "demander_visuel_au_studio"
+      max_per_day: 10
+
+human_oversight:
+  regime: "human_in_the_loop"
+  # Validation systematique au moment de la publication
+  # + revue par echantillonnage statistique pour detection de derive.
+  sampling_review:
+    frequency: "hebdomadaire"
+    sample_size_percent: 10
+    reviewer_role: "responsable_editorial"
+
+expiration:
+  max_duration_months: 12

--- a/templates/agent-marketing-contenu/mandate.yaml
+++ b/templates/agent-marketing-contenu/mandate.yaml
@@ -1,0 +1,301 @@
+# AMR Mandate Template — Agent Marketing & Contenu
+# Version 1.0 — langue: fr — juridiction: FR-EU
+# Ce fichier est un gabarit. Les valeurs entre < > doivent etre renseignees
+# par l'organisation qui emet le mandat avant chargement dans le registre AMR.
+
+metadata:
+  template_id: "amr-tpl-marketing-contenu-v1"
+  template_version: "1.0.0"
+  domain: "marketing-communication"
+  subdomain: "production-contenu-editorial"
+  language: "fr"
+  jurisdiction: "FR-EU"
+  created_at: "2026-04-22"
+  reference_standards:
+    - "Regulation (EU) 2024/1689 — AI Act (article 50 — transparence et marquage)"
+    - "Regulation (EU) 2016/679 — GDPR"
+    - "Regulation (EU) 2022/2065 — Digital Services Act"
+    - "Code de la propriete intellectuelle (France) — articles L.122-4, L.122-5, L.335-2"
+    - "Code de la consommation (France) — articles L.121-1 a L.121-5, L.132-2"
+    - "Loi n. 2004-575 du 21 juin 2004 (LCEN) — article 6"
+
+principal:
+  type: "legal_entity"
+  legal_name: "<Raison sociale du mandant>"
+  registration:
+    country: "FR"
+    id_type: "SIREN"
+    id_value: "<SIREN 9 chiffres>"
+  representative:
+    name: "<Nom du representant habilite>"
+    role: "<Fonction — ex: Directeur Marketing, Directeur Communication>"
+    email: "<email@entreprise.fr>"
+  legal_basis_gdpr:
+    article: "6(1)(f)"
+    description: "Interet legitime — communication commerciale a destination de prospects et clients existants — requiert test de mise en balance documente"
+    alternative_basis:
+      article: "6(1)(a)"
+      description: "Consentement — requis pour la prospection electronique B2C, article L.34-5 du Code des postes et communications electroniques"
+
+agent:
+  agent_id: "<identifiant unique interne de l'agent>"
+  display_name: "<nom fonctionnel — ex: Assistant-Editorial-Marque>"
+  provider: "<editeur ou equipe interne>"
+  model:
+    family: "<famille — ex: Claude, GPT, Mistral>"
+    version: "<version specifique deployee>"
+    hosted_in: "<zone d'hebergement — ex: EU-West>"
+  purpose: "Produire des contenus editoriaux, des variantes de posts sociaux, des sequences email et des optimisations SEO, sans publier ni envoyer sans validation humaine au-dela des seuils definis."
+  output_marking:
+    ai_act_article_50_paragraph_4: true
+    marking_rule: "Tout contenu genere ou substantiellement modifie par l'agent porte une mention machine-readable (metadonnee C2PA ou equivalente) et, lorsque le contexte editorial l'exige, une mention humaine visible."
+  user_disclosure:
+    ai_act_article_50_paragraph_1: true
+    disclosure_text_fr: "Cette interaction est assistee par une intelligence artificielle. Vous pouvez demander a echanger avec un membre de l'equipe."
+    disclosure_channels:
+      - "chatbot_site_public"
+      - "formulaire_intelligent"
+      - "assistant_editorial_externe"
+
+scope:
+  business_processes:
+    - "generation_post_reseaux_sociaux"
+    - "redaction_article_blog"
+    - "redaction_email_marketing"
+    - "optimisation_seo_page_existante"
+    - "brief_creatif_pour_designer"
+    - "recyclage_asset_existant"
+    - "traduction_contenu_existant"
+  channels_authorized:
+    - "linkedin"
+    - "instagram"
+    - "x_twitter"
+    - "blog_corporate"
+    - "newsletter_opt_in"
+    - "site_web_public"
+  geographic_scope:
+    - "FR"
+    - "EU"
+  languages_supported:
+    - "fr"
+    - "en"
+  excluded_processes:
+    - "publication_directe_sans_validation_humaine"
+    - "envoi_email_a_liste_non_opt_in"
+    - "generation_image_personne_identifiable_sans_consentement"
+    - "generation_voix_synthese_personne_identifiable"
+    - "communication_de_crise"
+    - "communication_resultats_financiers_societe_cotee"
+    - "prise_de_position_politique_ou_religieuse"
+    - "comparaison_nominative_avec_concurrent"
+
+permissions:
+  read:
+    - resource: "bibliotheque_assets_internes"
+      max_volume_per_day: 5000
+      fields_allowed:
+        - "texte_marketing_valide"
+        - "image_libre_de_droits_internes"
+        - "fiche_produit_publiee"
+        - "etude_de_cas_validee"
+        - "charte_editoriale"
+        - "guide_de_marque"
+      fields_forbidden:
+        - "donnees_clients_nominatives"
+        - "contrats_partenaires"
+        - "documents_strategiques_confidentiels"
+        - "donnees_financieres_non_publiques"
+    - resource: "donnees_audience_anonymisees"
+      max_volume_per_day: 50000
+      fields_allowed:
+        - "segment_id"
+        - "centre_interet_categorie"
+        - "comportement_agrege_anonymise"
+      fields_forbidden:
+        - "nom"
+        - "email"
+        - "telephone"
+        - "identifiant_individuel_reconciliable"
+  write:
+    - resource: "brouillon_contenu_a_valider"
+      max_volume_per_day: 200
+      max_tokens_per_output: 3000
+    - resource: "variante_post_social"
+      max_volume_per_day: 100
+      max_tokens_per_output: 600
+    - resource: "brief_creatif_interne"
+      max_volume_per_day: 50
+  invoke:
+    - action: "publier_post_social"
+      max_per_day: 0
+      requires_human_approval: true
+      approval_role: "responsable_editorial"
+    - action: "envoyer_campagne_email"
+      max_per_day: 0
+      requires_human_approval: true
+      approval_role: "responsable_marketing_direct"
+    - action: "soumettre_brouillon_au_cms"
+      max_per_day: 30
+      requires_human_approval: true
+      approval_role: "redacteur_en_chef"
+    - action: "demander_visuel_au_studio"
+      max_per_day: 20
+
+restrictions:
+  forbidden_actions:
+    - "publier_sans_validation_humaine"
+    - "envoyer_email_sans_validation_humaine"
+    - "citer_marque_tierce_sans_autorisation_documentee"
+    - "reproduire_oeuvre_protegee_sans_licence"
+    - "generer_image_personne_identifiable_sans_consentement"
+    - "generer_deepfake_audio_video"
+    - "formuler_claim_chiffre_non_source"
+    - "comparer_nominativement_avec_concurrent"
+    - "promettre_resultat_chiffre_non_garanti"
+    - "produire_contenu_a_destination_mineurs_sans_supervision"
+    - "transferer_donnees_audience_hors_UE"
+  ip_rules:
+    description: >
+      L'agent ne peut reproduire ni transformer une oeuvre protegee sans
+      licence ecrite. La citation breve est encadree par l'article L.122-5,
+      paragraphe 3, point a) du Code de la propriete intellectuelle :
+      mention de la source et du nom de l'auteur, finalite critique,
+      polemique, pedagogique, scientifique ou d'information, caractere bref.
+    explicit_rules:
+      - "verifier_droits_image_avant_usage"
+      - "respecter_droit_moral_auteur"
+      - "ne_pas_revendiquer_paternite_humaine_sur_contenu_genere"
+  brand_safety:
+    excluded_topics:
+      - "politique_partisane"
+      - "religion"
+      - "tragedie_actualite_recente"
+      - "minorites_stigmatisees_sans_validation_dei"
+    tone_guard: "respect_charte_editoriale_obligatoire"
+
+data_access:
+  categories:
+    - label: "donnees_audience_segmentaires"
+      sensitivity: "personal_aggregated"
+      gdpr_basis: "6(1)(f)"
+    - label: "donnees_prospects_opt_in"
+      sensitivity: "personal"
+      gdpr_basis: "6(1)(a)"
+    - label: "contenu_editorial_interne"
+      sensitivity: "internal_business"
+      gdpr_basis: "non_applicable"
+  special_categories_article_9: "non_autorise"
+  retention:
+    drafts_days: 365
+    published_assets_days: "duree_de_vie_commerciale_du_produit"
+    audience_data_days: "alignement_politique_generale_du_responsable_de_traitement"
+    justification: "Les brouillons sont conserves 12 mois pour traçabilite editoriale ; les durees produits relevent de la politique generale. A VALIDER PAR DPO."
+  data_minimization: true
+  transfer_outside_eu: false
+  training_on_proprietary_data:
+    allowed: false
+    note: "Les contenus de marque ne sont pas reutilises pour entrainer un modele tiers, sauf accord ecrit du responsable de traitement et du conseil juridique."
+
+human_oversight:
+  regime: "human_in_the_loop"
+  ai_act_reference: "Article 14 (principe general) + Article 50 (transparence et marquage) + Article 26 (deployeur)"
+  mandatory_validation_before_publication: true
+  mandatory_escalation_triggers:
+    - trigger: "contenu_evoquant_personne_physique_identifiable"
+      threshold: "toute_mention"
+    - trigger: "contenu_evoquant_marque_tierce"
+      threshold: "toute_mention_non_inscrite_liste_blanche"
+    - trigger: "claim_chiffre_ou_promesse_de_resultat"
+      threshold: "tout_chiffre_non_source"
+    - trigger: "sujet_sensible_detecte"
+      threshold: "politique_religion_sante_finance_minorites"
+    - trigger: "ton_hors_charte_detecte"
+      threshold: "score_alignement_charte_inferieur_a_seuil"
+    - trigger: "demande_communication_de_crise"
+      threshold: "toute_demande"
+  sampling_review:
+    frequency: "hebdomadaire"
+    sample_size_percent: 10
+    reviewer_role: "responsable_editorial"
+  reviewer_profile:
+    role: "redacteur_en_chef_ou_responsable_editorial"
+    training_required: true
+    training_topics:
+      - "limites_de_l_agent"
+      - "droit_d_auteur_et_droit_des_marques"
+      - "RGPD_prospection_et_profilage"
+      - "AI_Act_articles_50_et_26"
+      - "code_de_la_consommation_pratiques_commerciales"
+
+expiration:
+  valid_from: "<AAAA-MM-JJ>"
+  valid_until: "<AAAA-MM-JJ — 12 mois maximum recommande>"
+  max_duration_months: 12
+  revocation:
+    immediate_triggers:
+      - "incident_de_marque_confirme"
+      - "plainte_d_un_tiers_sur_droit_d_auteur"
+      - "mise_a_jour_majeure_du_modele_llm"
+      - "changement_de_charte_editoriale"
+      - "changement_de_prestataire_hebergement"
+      - "demande_d_une_autorite_de_controle"
+    revocation_contacts:
+      - "<directeur-marketing@entreprise.fr>"
+      - "<dpo@entreprise.fr>"
+      - "<juridique@entreprise.fr>"
+
+audit_trail:
+  logged_events:
+    - "ouverture_session"
+    - "lecture_asset_interne"
+    - "generation_brouillon"
+    - "marquage_contenu_genere_AI_Act_article_50_4"
+    - "soumission_pour_validation"
+    - "decision_humaine_validation_ou_refus"
+    - "publication_effective_par_humain"
+    - "incident_signale"
+  log_retention_days: 1825
+  log_retention_justification: "5 ans — alignement avec la prescription de l'action en contrefacon (Code de la propriete intellectuelle, article L.331-1-4) et la duree maximale d'examen DGCCRF. A VALIDER PAR JURISTE."
+  log_access:
+    - "dpo"
+    - "direction_marketing"
+    - "direction_juridique"
+    - "audit_interne"
+    - "autorite_de_controle_sur_requisition"
+  tamper_evidence: "sha256_chain"
+
+compliance_mapping:
+  ai_act:
+    classification: "limited_risk_transparency_obligation"
+    annex: "non_applicable_annex_III"
+    articles:
+      - "Article 50, paragraphe 1 — transparence vis-a-vis des personnes physiques"
+      - "Article 50, paragraphe 4 — marquage des contenus generes ou modifies par IA"
+      - "Article 26 — obligations du deployeur"
+      - "Article 99, paragraphe 4 — sanctions manquement article 50"
+  gdpr:
+    articles:
+      - "Article 6 — base legale (interet legitime ou consentement)"
+      - "Article 7 — conditions du consentement"
+      - "Article 13 — information des personnes"
+      - "Article 21 — droit d'opposition au profilage"
+      - "Article 22 — decision automatisee (a verifier si segmentation produit effets)"
+      - "Article 32 — securite du traitement"
+  dsa_eu_2022_2065:
+    - "Article 26 — transparence de la publicite en ligne (si plateforme intermediaire)"
+    - "Article 28 — protection des mineurs"
+  national_law_fr:
+    - "Code de la propriete intellectuelle, article L.122-4 — interdiction reproduction sans autorisation"
+    - "Code de la propriete intellectuelle, article L.122-5 — exceptions (citation breve)"
+    - "Code de la propriete intellectuelle, article L.335-2 — sanctions contrefacon"
+    - "Code de la consommation, article L.121-1 — pratiques commerciales deloyales"
+    - "Code de la consommation, article L.121-2 — pratiques trompeuses"
+    - "Code de la consommation, article L.132-2 — sanctions"
+    - "Code des postes et communications electroniques, article L.34-5 — prospection electronique"
+    - "Loi n. 2004-575 (LCEN), article 6 — responsabilite des hebergeurs et editeurs"
+
+signature:
+  method: "<eIDAS qualifie | avance | interne>"
+  signed_at: "<AAAA-MM-JJ>"
+  signatory: "<nom et fonction>"
+  signature_ref: "<reference de la signature ou hash>"


### PR DESCRIPTION
Template Tier 3 #3 livré : agent marketing & contenu (production éditoriale, posts sociaux, séquences email, SEO) avec gabarit complet — README, mandate.yaml, 3 profils permissif/restrictif/équilibré, 3 fiches compliance AI Act/RGPD/sectoriel, deploy_guide.
Vendable 2-5k€ tel quel à toute ETI ayant déployé ou voulant déployer un agent éditorial : impose le marquage AI Act article 50.4, exclut toute publication directe sans validation humaine, borne la propriété intellectuelle (L.122-4, L.713-2) et les pratiques commerciales (L.121-1).
À valider humainement : choix base légale RGPD selon canal/pays (intérêt légitime vs consentement), liste blanche des marques tierces autorisées, étendue exacte de la mention humaine visible (article 50.4) selon la nature du contenu.
Effort Audric pour merger : 5 minutes (lecture rapide README + mandate.yaml, vérifier ton aligné avec voix AMR).

## Auto-check

1. **Vendable en l'état ?** Oui. Structure complète, YAML validés, pricing aligné Tier 3, exclusions explicites, zones À VALIDER PAR JURISTE clairement marquées (c'est ce qui justifie le prix : structure prête, juriste client valide les zones grises).
2. **Ce qu'un juriste corrigerait en premier ?** L'interprétation de l'étendue de l'obligation de mention visible de l'article 50, paragraphe 4 sur les contenus marketing — la doctrine n'est pas stabilisée. Le gabarit prend une lecture prudente et marque le point comme à valider, posture défendable.
3. **30% à couper sans perte ?** Sections sectorielles immobilier/tabac/jeux dans `compliance/sector_specific.md` sont marginales pour la majorité des déploiements ETI B2B, mais elles donnent confiance que le template est exhaustif. Pas de coupe recommandée.