### PR TITLE
Update post Digital Omnibus + add CSA 82% stat

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,6 +737,11 @@ html[lang="fr"] .hero-ctas a[data-lang="en"] { display: none; }
     <blockquote class="pull-quote" data-lang="fr">« Comment prouver qu'un agent IA a l'autorité légale d'agir au nom de quelqu'un ? »</blockquote>
   </div>
 
+  <div class="reveal" style="background: var(--bg-alt); padding: var(--space-md); border-left: 3px solid var(--sage); border-radius: 3px; margin: var(--space-md) 0; max-width: 680px;">
+    <p class="section-text" data-lang="en" style="margin: 0;"><strong>The reality.</strong> 82% of organizations discovered unknown AI agents on their networks in the past year (Cloud Security Alliance, April 2026). Only 1 in 5 has a decommissioning process. Without a mandate registry, you don't know which agents are authorized to act for you — let alone which ones are still running.</p>
+    <p class="section-text" data-lang="fr" style="margin: 0;"><strong>La réalité.</strong> 82% des organisations ont découvert des agents IA inconnus sur leurs réseaux dans l'année (Cloud Security Alliance, avril 2026). Seulement 1 sur 5 a un processus de décommissionnement. Sans registre de mandats, vous ne savez pas quels agents sont autorisés à agir pour vous — et encore moins lesquels tournent encore.</p>
+  </div>
+
   <div class="reveal">
     <p class="section-text" data-lang="en">Today, agent frameworks handle permissions and authentication. But permissions ≠ legal mandate. A database ACL doesn't hold up in court. An API key doesn't prove informed consent. The EU AI Act requires a named human sponsor for each agent (Article 14) and deployer obligations including oversight and audit logs (Article 26). But without a mandate registry, that human sponsor field is just a name attached retroactively — it doesn't prove prospective authorization. No current framework bridges this gap.</p>
     <p class="section-text" data-lang="fr">Aujourd'hui, les frameworks d'agents gèrent les permissions et l'authentification. Mais permission ≠ mandat légal. Une ACL de base de données ne tient pas devant un tribunal. Une clé API ne prouve pas le consentement éclairé. L'AI Act exige un humain responsable nommé pour chaque agent (Article 14) et des obligations de supervision et logs d'audit pour les déployeurs (Article 26). Mais sans registre de mandats, ce champ "humain responsable" n'est qu'un nom collé après coup — il ne prouve pas l'autorisation prospective. Aucun framework actuel ne comble ce vide.</p>
@@ -988,8 +993,8 @@ html[lang="fr"] .hero-ctas a[data-lang="en"] { display: none; }
 <!-- FINAL CTA -->
 <section class="final-cta">
   <div class="reveal">
-    <h2 data-lang="en">The AI Act high-risk deadline is August 2, 2026.<br>The Digital Omnibus may delay it — but it hasn't yet.<br>Are your agents ready for either scenario?</h2>
-    <h2 data-lang="fr">La date AI Act haut risque est le 2 août 2026.<br>Le Digital Omnibus pourrait la repousser — mais ce n'est pas encore fait.<br>Vos agents sont-ils prêts dans les deux cas ?</h2>
+    <h2 data-lang="en">Annex III high-risk obligations: December 2, 2027 (Digital Omnibus, provisional agreement May 7, 2026).<br>Article 50 transparency: August 2, 2026 — confirmed.<br>The window to build a mandate registry is now.</h2>
+    <h2 data-lang="fr">Obligations Annex III haut risque : 2 décembre 2027 (Digital Omnibus, accord provisoire du 7 mai 2026).<br>Transparence Article 50 : 2 août 2026 — confirmé.<br>La fenêtre pour bàtir un registre de mandats, c'est maintenant.</h2>
 
     <div class="hero-ctas">
       <a href="https://github.com/JC7333/amr" target="_blank" rel="noopener" class="btn-primary" data-lang="en">Star on GitHub →</a>


### PR DESCRIPTION
Met a jour le CTA final avec les nouvelles deadlines Digital Omnibus (Annex III 02/12/2027, Art.50 02/08/2026 confirme) et ajoute un encart proof point dans la section Mandate Gap avec la stat Cloud Security Alliance (82% des orgs ont des agents IA inconnus sur leurs reseaux, avril 2026).